### PR TITLE
Removed unnecessary memory allocation

### DIFF
--- a/src/binding/util.rs
+++ b/src/binding/util.rs
@@ -1,6 +1,6 @@
 use rubysys::util as rubysys_util;
 
-use types::{Id, Value};
+use types::{c_char, c_long, Id, Value};
 use util;
 
 pub fn get_constant(name: &str, parent_object: Value) -> Value {
@@ -10,9 +10,10 @@ pub fn get_constant(name: &str, parent_object: Value) -> Value {
 }
 
 pub fn internal_id(string: &str) -> Id {
-    let str = util::str_to_cstring(string);
+    let str = string.as_ptr() as *const c_char;
+    let len = string.len() as c_long;
 
-    unsafe { rubysys_util::rb_intern(str.as_ptr()) }
+    unsafe { rubysys_util::rb_intern2(str, len) }
 }
 
 pub fn call_method(receiver: Value, method: &str, arguments: Option<Vec<Value>>) -> Value {

--- a/src/rubysys/util.rs
+++ b/src/rubysys/util.rs
@@ -8,5 +8,6 @@ extern "C" {
     pub fn rb_scan_args(argc: Argc, argv: *const Value, fmt: *const c_char, ...) -> c_int;
     pub fn rb_ary_new_from_values(n: c_long, args: *const Value) -> Value;
     pub fn rb_intern(name: *const c_char) -> Id;
+    pub fn rb_intern2(name: *const c_char, len: c_long) -> Id;
     pub fn rb_id2name(method_id: Id) -> *const c_char;
 }


### PR DESCRIPTION
Removed unnecessary transformation from `str` to `CString` by using `rb_intern2`.
