### PR TITLE
Implement RString::concat

### DIFF
--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -61,3 +61,10 @@ pub fn value_to_str_unchecked<'a>(value: Value) -> &'a str {
 pub fn bytesize(value: Value) -> i64 {
     unsafe { string::rb_str_len(value) as i64 }
 }
+
+pub fn concat(value: Value, bytes: &[u8]) -> Value {
+    let str = bytes.as_ptr() as *const c_char;
+    let len = bytes.len() as c_long;
+
+    unsafe { string::rb_str_cat(value, str, len) }
+}

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -238,6 +238,32 @@ impl RString {
     pub fn bytesize(&self) -> i64 {
         string::bytesize(self.value())
     }
+
+    /// Appends a given string slice onto the end of this String.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{RString, VM};
+    /// # VM::init();
+    ///
+    /// let mut string = RString::new("Hello, ");
+    /// string.concat("World!");
+    ///
+    /// assert_eq!(string.to_string(), "Hello, World!".to_string());
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// str = 'Hello, '
+    /// str << 'World!'
+    ///
+    /// str == 'Hello, World!'
+    /// ```
+    pub fn concat(&mut self, string: &str) {
+        string::concat(self.value(), string.as_bytes());
+    }
 }
 
 impl From<Value> for RString {

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -13,6 +13,7 @@ extern "C" {
     pub fn rb_str_ascii_only_p(str: Value) -> bool;
     pub fn rb_str_export_locale(str: Value) -> Value;
     pub fn rb_str_valid_encoding_p(str: Value) -> bool;
+    pub fn rb_str_cat(str: Value, ptr: *const c_char, len: c_long) -> Value;
 }
 
 #[repr(C)]


### PR DESCRIPTION
I think in most use cases, we wanted to concatenate Rust strings, so I implemented a `&str` API in `src/class/string.rs`. On the other hand, the API in `src/binding/string.rs` is set to `&[u8]` because of a small use case (for example, when concatenating non-UTF-8 character strings).

