### PR TITLE
Add backwards compatibility to Rust 1.25

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,171 +3,173 @@ os: Visual Studio 2015
 environment:
   matrix:
 
-  # Ruby 2.4
-
 ### MSVC Toolchains ###
 
+  # Ruby 2.4
+
   # Stable 64-bit MSVC
-    - channel: stable
+    - channel: 1.25.0
       target: x86_64-pc-windows-msvc
       platform: x64
       RUBY_VERSION: 24
       RUST_BACKTRACE: full
   # Stable 32-bit MSVC
-    - channel: stable
+    - channel: 1.25.0
       target: i686-pc-windows-msvc
       platform: x86
       RUBY_VERSION: 24
       RUST_BACKTRACE: full
-  # Beta 64-bit MSVC
-    - channel: beta
-      target: x86_64-pc-windows-msvc
-      platform: x64
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-  # Beta 32-bit MSVC
-    - channel: beta
-      target: i686-pc-windows-msvc
-      platform: x86
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-  # Nightly 64-bit MSVC
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
-      platform: x64
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
-  # Nightly 32-bit MSVC
-    - channel: nightly
-      target: i686-pc-windows-msvc
-      platform: x86
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
+#  # Beta 64-bit MSVC
+#    - channel: beta
+#      target: x86_64-pc-windows-msvc
+#      platform: x64
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#  # Beta 32-bit MSVC
+#    - channel: beta
+#      target: i686-pc-windows-msvc
+#      platform: x86
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#  # Nightly 64-bit MSVC
+#    - channel: nightly
+#      target: x86_64-pc-windows-msvc
+#      platform: x64
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
+#  # Nightly 32-bit MSVC
+#    - channel: nightly
+#      target: i686-pc-windows-msvc
+#      platform: x86
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
 
   # Ruby 2.5
 
   # Stable 64-bit MSVC
-    - channel: stable
+    - channel: 1.25.0
       target: x86_64-pc-windows-msvc
       platform: x64
       RUBY_VERSION: 25
       RUST_BACKTRACE: full
   # Stable 32-bit MSVC
-    - channel: stable
+    - channel: 1.25.0
       target: i686-pc-windows-msvc
       platform: x86
       RUBY_VERSION: 25
       RUST_BACKTRACE: full
-  # Beta 64-bit MSVC
-    - channel: beta
-      target: x86_64-pc-windows-msvc
-      platform: x64
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-  # Beta 32-bit MSVC
-    - channel: beta
-      target: i686-pc-windows-msvc
-      platform: x86
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-  # Nightly 64-bit MSVC
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
-      platform: x64
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
-  # Nightly 32-bit MSVC
-    - channel: nightly
-      target: i686-pc-windows-msvc
-      platform: x86
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
-
+#  # Beta 64-bit MSVC
+#    - channel: beta
+#      target: x86_64-pc-windows-msvc
+#      platform: x64
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#  # Beta 32-bit MSVC
+#    - channel: beta
+#      target: i686-pc-windows-msvc
+#      platform: x86
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#  # Nightly 64-bit MSVC
+#    - channel: nightly
+#      target: x86_64-pc-windows-msvc
+#      platform: x64
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
+#  # Nightly 32-bit MSVC
+#    - channel: nightly
+#      target: i686-pc-windows-msvc
+#      platform: x86
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
+#
 ### GNU Toolchains ###
 
+  # Ruby 2.4
+
   # Stable 64-bit GNU
-    - channel: stable
+    - channel: 1.25.0
       target: x86_64-pc-windows-gnu
       platform: x64
       RUBY_VERSION: 24
       RUST_BACKTRACE: full
   # Stable 32-bit GNU
-    - channel: stable
+    - channel: 1.25.0
       target: i686-pc-windows-gnu
       platform: x86
       RUBY_VERSION: 24
       RUST_BACKTRACE: full
-  # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
-      platform: x64
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-  # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
-      platform: x86
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-  # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-      platform: x64
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
-  # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
-      platform: x86
-      RUBY_VERSION: 24
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
+#  # Beta 64-bit GNU
+#    - channel: beta
+#      target: x86_64-pc-windows-gnu
+#      platform: x64
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#  # Beta 32-bit GNU
+#    - channel: beta
+#      target: i686-pc-windows-gnu
+#      platform: x86
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#  # Nightly 64-bit GNU
+#    - channel: nightly
+#      target: x86_64-pc-windows-gnu
+#      platform: x64
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
+#  # Nightly 32-bit GNU
+#    - channel: nightly
+#      target: i686-pc-windows-gnu
+#      platform: x86
+#      RUBY_VERSION: 24
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
 
   # Ruby 2.5
 
   # Stable 64-bit GNU
-    - channel: stable
+    - channel: 1.25.0
       target: x86_64-pc-windows-gnu
       platform: x64
       RUBY_VERSION: 25
       RUST_BACKTRACE: full
   # Stable 32-bit GNU
-    - channel: stable
+    - channel: 1.25.0
       target: i686-pc-windows-gnu
       platform: x86
       RUBY_VERSION: 25
       RUST_BACKTRACE: full
-  # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
-      platform: x64
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-  # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
-      platform: x86
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-  # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-      platform: x64
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
-  # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
-      platform: x86
-      RUBY_VERSION: 25
-      RUST_BACKTRACE: full
-      #cargoflags: --features "unstable"
+#  # Beta 64-bit GNU
+#    - channel: beta
+#      target: x86_64-pc-windows-gnu
+#      platform: x64
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#  # Beta 32-bit GNU
+#    - channel: beta
+#      target: i686-pc-windows-gnu
+#      platform: x86
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#  # Nightly 64-bit GNU
+#    - channel: nightly
+#      target: x86_64-pc-windows-gnu
+#      platform: x64
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
+#  # Nightly 32-bit GNU
+#    - channel: nightly
+#      target: i686-pc-windows-gnu
+#      platform: x86
+#      RUBY_VERSION: 25
+#      RUST_BACKTRACE: full
+#      #cargoflags: --features "unstable"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 - osx
 
 rust:
+  - 1.25.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rutie"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
   "Steve Klabnik <steve@steveklabnik.com>",
   "Dmitry Gritsay <unseductable@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ First add the dependency to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rutie = "0.3.0"
+rutie = "0.3.1"
 ```
 
 Then in your Rust program add `VM::init()` to the beginning of its code execution path
@@ -87,7 +87,7 @@ file.  Add Rutie to the `Cargo.toml` file and define the lib type.
 
 ```toml
 [dependencies]
-rutie = "0.3.0"
+rutie = "0.3.1"
 
 [lib]
 name = "rutie_ruby_example"

--- a/src/util.rs
+++ b/src/util.rs
@@ -49,8 +49,8 @@ pub fn process_arguments(arguments: &[Value]) -> (Argc, *const Value) {
 
 pub fn option_to_slice<'a, T>(option: &'a Option<T>) -> &'a [T] {
     match option {
-        Some(v) => unsafe { slice::from_raw_parts(v, 1) },
-        None => &[],
+        &Some(ref v) => unsafe { slice::from_raw_parts(v, 1) },
+        &None => &[],
     }
 }
 


### PR DESCRIPTION
Recent versions of Rust allow for simpler syntax but we should still support a reasonable amount of older Rust versions.