### PR TITLE
Change `vm::protect` signature

### DIFF
--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -351,7 +351,7 @@ impl VM {
 
     pub fn protect<F>(func: F) -> Result<Value, i32>
     where
-        F: FnOnce(),
+        F: FnMut() -> Value,
     {
         vm::protect(func)
     }


### PR DESCRIPTION
[`FnOnce` consumes the variables](https://doc.rust-lang.org/beta/book/second-edition/ch13-01-closures.html#capturing-the-environment-with-closures). In other words, `FnOnce` may contain releasing resources. However, `rb_protect` expects a Ruby exception to occur internally, so it is not good to pass a function containing resource release.
I changed the signature of `vm::protect` from `FnOnce` to `FnMut` and removed heap allocations.

With this pull request and the previous pull request #17, `vm::protect` no longer needs heap allocation. Perhaps #4 may be fixed.