### PR TITLE
Add an example: eval

### DIFF
--- a/examples/eval.rs
+++ b/examples/eval.rs
@@ -15,7 +15,7 @@ fn main() {
             },
         }
     } else {
-        eprintln!("No argument");
+        eprintln!(r#"Usage: eval "puts 'Put ruby code to be evaluated in a string after eval.' ""#);
         process::exit(1);
     }
 }

--- a/examples/eval.rs
+++ b/examples/eval.rs
@@ -1,0 +1,21 @@
+extern crate rutie;
+
+use rutie::VM;
+use std::{env, process};
+
+fn main() {
+    VM::init();
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 {
+        match VM::eval(&args[1]) {
+            Ok(_) => (),
+            Err(e) => {
+                println!("{}", e);
+                process::exit(1);
+            },
+        }
+    } else {
+        eprintln!("No argument");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
I created an example that execute argument string as Ruby script.

```shell
$ cargo build --example eval
$ ./target/debug/examples/eval "puts 'Hello'"
Hello
```

This program is an example and also I'm considering the following usage for testing of build.

```shell
$ cargo clean; cargo run --quiet --example eval 'puts RUBY_VERSION'
2.5.1
$ cargo clean; cargo +1.25.0 run --quiet --example eval 'puts RUBY_VERSION'
2.5.1
$ cargo clean; RUBY=/usr/bin/ruby cargo run --quiet --example eval 'puts RUBY_VERSION'
2.3.3
$ cargo clean; RBENV_VERSION=2.3.7 cargo run --quiet --example eval 'puts RUBY_VERSION'
error: linking with `cc` failed: exit code: 1
...
```
