### PR TITLE
Fix build.rs to use RbConfig::CONFIG['ruby_pc']

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,14 @@ fn use_dylib() {
     println!("cargo:rustc-link-lib=dylib={}", rbconfig("RUBY_SO_NAME"));
 }
 
+fn trim_ext(mut name: String, ext: &str) -> String {
+    if name.ends_with(ext) {
+        let len = name.len();
+        name.truncate(len - ext.len());
+    }
+    name
+}
+
 fn main() {
     // Ruby programs calling Rust don't need cc linking
     if let None = std::env::var_os("NO_LINK_RUTIE") {
@@ -51,8 +59,20 @@ fn main() {
 
         if let Ok(_) = pkg_config::probe_library(&rbconfig("RUBY_SO_NAME")) {
            // Using pkg-config
-        } else if rbconfig("target_os") != "mingw32" && env::var_os("RUBY_STATIC").is_some() {
-            use_static()
+           return;
+        }
+        let pc_name = trim_ext(rbconfig("ruby_pc"), ".pc");
+        if !pc_name.is_empty() {
+            if let Ok(_) = pkg_config::probe_library(&pc_name) {
+                println!("# use ruby_pc");
+                if rbconfig("ENABLE_SHARED") == "no" {
+                    println!("cargo:rustc-link-lib=ruby");
+                }
+                return;
+            }
+        }
+        if rbconfig("target_os") != "mingw32" && env::var_os("RUBY_STATIC").is_some() {
+            use_static();
         } else {
             match rbconfig("ENABLE_SHARED").as_str() {
                 "no" => use_static(),


### PR DESCRIPTION
I modified build.rs to use pkg-config. A test is done only on my Mac, but backward compatibility is not destroyed and I think that there is no problem.

---

There are 6 Ruby installed on my Mac.
- Initially installed
- Installed using homebrew (`brew install ruby`)
- Installed using rbenv
    - `CONFIGURE_OPTS="--enable-shared" rbenv install 2.3.6`
    - `rbenv install 2.3.7`
    - `CONFIGURE_OPTS="--enable-shared" rbenv install 2.5.0`
    - `rbenv install 2.5.1`

I ran the following script.
```bash
#!/bin/bash

build_test() {
  printf "** %s **\n" "$1"
  cargo clean
  which "${RUBY:-ruby}"
  ${RUBY:-ruby} -v
  ${RUBY:-ruby} -e 'puts "ENABLE_SHARED = " + RbConfig::CONFIG["ENABLE_SHARED"] '
  cargo run --quiet --example eval 'puts "Success to build"'
  if cat target/debug/build/rutie-*/output | grep 'use ruby_pc' > /dev/null; then
      echo "build with pkg-config"
  else
      echo "build without pkg-config"
  fi
  sleep 1
  echo
}

RUBY=/usr/bin/ruby build_test "Build-in"
RUBY=/usr/local/bin/ruby build_test "Homebrew"
RBENV_VERSION=2.3.6 build_test "rbenv 2.3.6"
RBENV_VERSION=2.3.7 build_test "rbenv 2.3.7"
RBENV_VERSION=2.5.0 build_test "rbenv 2.5.0"
RBENV_VERSION=2.5.1 build_test "rbenv 2.5.1"
```

And I got the following result.

```
$ bash build-test.bash
** Build-in **
/usr/bin/ruby
ruby 2.3.3p222 (2016-11-21 revision 56859) [universal.x86_64-darwin17]
ENABLE_SHARED = yes
Success to build
build with pkg-config

** Homebrew **
/usr/local/bin/ruby
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]
ENABLE_SHARED = yes
Success to build
build with pkg-config

** rbenv 2.3.6 **
/Users/user/.rbenv/shims/ruby
ruby 2.3.6p384 (2017-12-14 revision 61254) [x86_64-darwin17]
ENABLE_SHARED = yes
Success to build
build with pkg-config

** rbenv 2.3.7 **
/Users/user/.rbenv/shims/ruby
ruby 2.3.7p456 (2018-03-28 revision 63024) [x86_64-darwin17]
ENABLE_SHARED = no
Success to build
build with pkg-config

** rbenv 2.5.0 **
/Users/user/.rbenv/shims/ruby
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]
ENABLE_SHARED = yes
Success to build
build with pkg-config

** rbenv 2.5.1 **
/Users/user/.rbenv/shims/ruby
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]
ENABLE_SHARED = no
Success to build
build with pkg-config
```