### PR TITLE
use `rb_str_strlen`

### DIFF
--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -50,7 +50,7 @@ pub fn value_to_str<'a>(value: Value) -> &'a str {
 pub fn value_to_bytes_unchecked<'a>(value: Value) -> &'a [u8] {
     unsafe {
         let str = string::rb_string_value_ptr(&value) as *const u8;
-        let len = string::rb_str_len(value) as usize;
+        let len = string::rb_str_strlen(value) as usize;
 
         ::std::slice::from_raw_parts(str, len)
     }
@@ -65,7 +65,7 @@ pub fn value_to_str_unchecked<'a>(value: Value) -> &'a str {
 }
 
 pub fn bytesize(value: Value) -> i64 {
-    unsafe { string::rb_str_len(value) as i64 }
+    unsafe { string::rb_str_strlen(value) as i64 }
 }
 
 pub fn concat(value: Value, bytes: &[u8]) -> Value {

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -27,6 +27,9 @@ extern "C" {
     // char *
     // rb_string_value_ptr(volatile VALUE *ptr)
     pub fn rb_string_value_ptr(str: *const Value) -> *const c_char;
+    // long
+    // rb_str_strlen(VALUE str)
+    pub fn rb_str_strlen(str: Value) -> c_long;
     // int
     // rb_enc_str_asciionly_p(VALUE str)
     pub fn rb_enc_str_asciionly_p(str: Value) -> bool;
@@ -90,18 +93,6 @@ struct RStringHeap {
 struct RString {
     basic: RBasic,
     as_: RStringAs,
-}
-
-pub unsafe fn rb_str_len(value: Value) -> c_long {
-    let rstring: *const RString = mem::transmute(value.value);
-    let flags = (*rstring).basic.flags;
-
-    if flags & (RStringEmbed::NoEmbed as size_t) == 0 {
-        ((flags as i64 >> RStringEmbed::LenShift as i64) &
-         (RStringEmbed::LenMask as i64 >> RStringEmbed::LenShift as i64)) as c_long
-    } else {
-        (*rstring).as_.heap.len
-    }
 }
 
 // ```


### PR DESCRIPTION
I deleted the handmade `rb_str_len` and used `rb_str_strlen`. Probably this function did not exist before, but [it exists at least in version 2.3.0](https://github.com/ruby/ruby/blob/v2_3_0/string.c#L1554).
I did not know whether to delete [other implementation parts](https://github.com/steveklabnik/ruby-sys/commit/a0ce422456237207493efaac444d5064126371d8), so I left it.
