### PR TITLE
Fix string length

### DIFF
--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -68,6 +68,10 @@ pub fn bytesize(value: Value) -> i64 {
     unsafe { string::rb_str_len(value) as i64 }
 }
 
+pub fn count_chars(value: Value) -> i64 {
+    unsafe { string::rb_str_strlen(value) as i64 }
+}
+
 pub fn concat(value: Value, bytes: &[u8]) -> Value {
     let str = bytes.as_ptr() as *const c_char;
     let len = bytes.len() as c_long;

--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -50,7 +50,7 @@ pub fn value_to_str<'a>(value: Value) -> &'a str {
 pub fn value_to_bytes_unchecked<'a>(value: Value) -> &'a [u8] {
     unsafe {
         let str = string::rb_string_value_ptr(&value) as *const u8;
-        let len = string::rb_str_strlen(value) as usize;
+        let len = string::rb_str_len(value) as usize;
 
         ::std::slice::from_raw_parts(str, len)
     }
@@ -65,7 +65,7 @@ pub fn value_to_str_unchecked<'a>(value: Value) -> &'a str {
 }
 
 pub fn bytesize(value: Value) -> i64 {
-    unsafe { string::rb_str_strlen(value) as i64 }
+    unsafe { string::rb_str_len(value) as i64 }
 }
 
 pub fn concat(value: Value, bytes: &[u8]) -> Value {

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -251,6 +251,34 @@ impl RString {
         string::bytesize(self.value())
     }
 
+    /// Returns the number of characters in the string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{RString, VM};
+    /// # VM::init();
+    ///
+    /// let string = RString::new_utf8("Hello, World!");
+    /// let utf8_string = RString::new_utf8("⓯");
+    ///
+    /// assert_eq!(string.count_chars(), 13);
+    /// assert_eq!(utf8_string.count_chars(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// string = 'Hello, World!'
+    /// utf8_string = '⓯'
+    ///
+    /// string.length == 13
+    /// utf8_string.length == 1
+    /// ```
+    pub fn count_chars(&self) -> i64 {
+        string::count_chars(self.value())
+    }
+
     /// Appends a given string slice onto the end of this String.
     ///
     /// # Examples

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -231,8 +231,8 @@ impl RString {
     /// use rutie::{RString, VM};
     /// # VM::init();
     ///
-    /// let string = RString::new("Hello, World!");
-    /// let utf8_string = RString::new("⓯");
+    /// let string = RString::new_utf8("Hello, World!");
+    /// let utf8_string = RString::new_utf8("⓯");
     ///
     /// assert_eq!(string.bytesize(), 13);
     /// assert_eq!(utf8_string.bytesize(), 3);

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -27,6 +27,9 @@ extern "C" {
     // char *
     // rb_string_value_ptr(volatile VALUE *ptr)
     pub fn rb_string_value_ptr(str: *const Value) -> *const c_char;
+    // long
+    // rb_str_strlen(VALUE str)
+    pub fn rb_str_strlen(str: Value) -> c_long;
     // int
     // rb_enc_str_asciionly_p(VALUE str)
     pub fn rb_enc_str_asciionly_p(str: Value) -> bool;

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -27,9 +27,6 @@ extern "C" {
     // char *
     // rb_string_value_ptr(volatile VALUE *ptr)
     pub fn rb_string_value_ptr(str: *const Value) -> *const c_char;
-    // long
-    // rb_str_strlen(VALUE str)
-    pub fn rb_str_strlen(str: Value) -> c_long;
     // int
     // rb_enc_str_asciionly_p(VALUE str)
     pub fn rb_enc_str_asciionly_p(str: Value) -> bool;
@@ -93,6 +90,18 @@ struct RStringHeap {
 struct RString {
     basic: RBasic,
     as_: RStringAs,
+}
+
+pub unsafe fn rb_str_len(value: Value) -> c_long {
+    let rstring: *const RString = mem::transmute(value.value);
+    let flags = (*rstring).basic.flags;
+
+    if flags & (RStringEmbed::NoEmbed as size_t) == 0 {
+        ((flags as i64 >> RStringEmbed::LenShift as i64) &
+         (RStringEmbed::LenMask as i64 >> RStringEmbed::LenShift as i64)) as c_long
+    } else {
+        (*rstring).as_.heap.len
+    }
 }
 
 // ```


### PR DESCRIPTION
1. Fixed test.
2. Revert #27
3. Implement Ruby's `String#length`

I think that it is better to rename `String::new()` to `String::new_usascii_unchecked()`.