### PR TITLE
Rename C-class name in dsl wrapper macro

### DIFF
--- a/build.md
+++ b/build.md
@@ -37,7 +37,7 @@ linking with Ruby please see the documentation for
 ## Disabling PKG-CONFIG
 
 Disabling the use of pkg-config will guarantee using the default fallback
-settings which were written in to the Ruru library.  You can disable the
+settings which were written in to the Rutie library.  You can disable the
 use of pkg-config in Rutie with setting the environment variable
 `RUTIE_NO_PKG_CONFIG`.
 

--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -4,7 +4,7 @@ use {Object, VerifiedObject};
 
 /// Representation of any Ruby object while its type is unknown
 ///
-/// As Ruby is a dynamically typed language, at some points Ruru does not know the exact Ruby type
+/// As Ruby is a dynamically typed language, at some points Rutie does not know the exact Ruby type
 /// of the object, for example:
 ///
 /// - Retrieving an object from array;

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -700,7 +700,7 @@ macro_rules! wrappable_struct {
 
         impl<T> $wrapper<T> {
             fn new() -> $wrapper<T> {
-                let name = concat!("Ruru/", stringify!($struct_name));
+                let name = concat!("Rutie/", stringify!($struct_name));
                 let name = $crate::util::str_to_cstring(name);
                 let reserved_bytes: [*mut $crate::types::c_void; 2] = [::std::ptr::null_mut(); 2];
 


### PR DESCRIPTION
While moving over from ruru, I ran into a `TypeError` that said some
Ruby method was expecting a `Ruru/MyClassThing` type of object; it was a
bit confusing seeing the "Ruru" part in there, making me think I hadn't
fully cleaned out old artifacts or something.

Also renamed a couple other spots in documentation.