### PR TITLE
rb_str_codepoints not available on all OSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ API and may have breaking changes during a teeny version change.
 
 ## [Unreleased]
 
+## [0.4.3] - 2018-10-23
+### Fixed
+- `RString.codepoints` uses a new internal implementation as `rb_str_codepoints` isn't exported/available on some OSes
+
+## [0.4.2] - 2018-10-16
+### Fixed
+- Wrapping struct changed from Ruru to Rutie & some of the same changes in documentation
+
+## [0.4.1] - 2018-10-04
+### Added
+- Static build support
+
 ## [0.4.0] - 2018-08-20
 ### Added
 - Methods `VM::yield_object` and `VM::yield_splat`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rutie"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   "Steve Klabnik <steve@steveklabnik.com>",
   "Dmitry Gritsay <unseductable@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ First add the dependency to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-rutie = "0.4.2"
+rutie = "0.4.3"
 ```
 
 Then in your Rust program add `VM::init()` to the beginning of its code execution path
@@ -89,7 +89,7 @@ file.  Add Rutie to the `Cargo.toml` file and define the lib type.
 
 ```toml
 [dependencies]
-rutie = "0.4.2"
+rutie = "0.4.3"
 
 [lib]
 name = "rutie_ruby_example"

--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -101,7 +101,3 @@ pub fn locktmp(str: Value) -> Value {
 pub fn unlocktmp(str: Value) -> Value {
     unsafe { string::rb_str_unlocktmp(str) }
 }
-
-pub fn codepoints(str: Value) -> Value {
-    unsafe { string::rb_str_codepoints(str) }
-}

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -17,6 +17,8 @@ use {
   TryConvert,
   Hash,
   Array,
+  CodepointIterator,
+  Integer,
 };
 
 /// `String`
@@ -305,8 +307,11 @@ impl RString {
     ///
     /// str.codepoints == [102, 111, 111, 37727, 97]
     /// ```
-    pub fn codepoints(&self) -> Array {
-        Array::from(string::codepoints(self.value()))
+    pub fn codepoints(self) -> Array {
+        CodepointIterator::new(self).
+            into_iter().
+            map(|n| Integer::new(n as i64).to_any_object()).
+            collect()
     }
 
     /// Returns the length of the string in bytes

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -66,9 +66,6 @@ extern "C" {
     // VALUE
     // rb_str_unlocktmp(VALUE str)
     pub fn rb_str_unlocktmp(str: Value) -> Value;
-    // static VALUE
-    // rb_str_codepoints(VALUE str)
-    pub fn rb_str_codepoints(str: Value) -> Value;
     // VALUE
     // rb_str_new_frozen(VALUE orig)
     pub fn rb_str_new_frozen(orig: Value) -> Value;


### PR DESCRIPTION
Windows doesn't have it and apparently some Mac OSes don't.