### PR TITLE
Use rb_num2long for i64 values

### DIFF
--- a/src/binding/fixnum.rs
+++ b/src/binding/fixnum.rs
@@ -6,6 +6,10 @@ pub fn int_to_num(num: i64) -> Value {
     unsafe { fixnum::rb_int2inum(num as SignedValue) }
 }
 
-pub fn num_to_int(num: Value) -> i64 {
-    unsafe { fixnum::rb_num2int(num) as i64 }
+pub fn num_to_int(num: Value) -> i32 {
+    unsafe { fixnum::rb_num2int(num) }
+}
+
+pub fn num_to_long(num: Value) -> i64 {
+    unsafe { fixnum::rb_num2long(num) }
 }

--- a/src/binding/hash.rs
+++ b/src/binding/hash.rs
@@ -32,7 +32,7 @@ pub fn length(hash: Value) -> i64 {
     unsafe {
         let size = hash::rb_hash_size(hash);
 
-        fixnum::num_to_int(size)
+        fixnum::num_to_long(size)
     }
 }
 

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -53,6 +53,28 @@ impl Fixnum {
     /// 1 == 1
     /// ```
     pub fn to_i64(&self) -> i64 {
+        fixnum::num_to_long(self.value())
+    }
+
+    /// Retrieves an `i32` value from `Fixnum`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Fixnum, VM};
+    /// # VM::init();
+    ///
+    /// let fixnum = Fixnum::new(1);
+    ///
+    /// assert_eq!(fixnum.to_i32(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_i32(&self) -> i32 {
         fixnum::num_to_int(self.value())
     }
 }

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -53,6 +53,29 @@ impl Integer {
     /// 1 == 1
     /// ```
     pub fn to_i64(&self) -> i64 {
+        fixnum::num_to_long(self.value())
+    }
+
+
+    /// Retrieves an `i32` value from `Integer`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Integer, VM};
+    /// # VM::init();
+    ///
+    /// let integer = Integer::new(1);
+    ///
+    /// assert_eq!(integer.to_i32(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_i32(&self) -> i32 {
         fixnum::num_to_int(self.value())
     }
 }
@@ -71,9 +94,16 @@ impl From<i64> for Integer {
 
 impl Into<i64> for Integer {
     fn into(self) -> i64 {
+        fixnum::num_to_long(self.value())
+    }
+}
+
+impl Into<i32> for Integer {
+    fn into(self) -> i32 {
         fixnum::num_to_int(self.value())
     }
 }
+
 
 impl From<Fixnum> for Integer {
     fn from(num: Fixnum) -> Self {

--- a/src/rubysys/fixnum.rs
+++ b/src/rubysys/fixnum.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{c_long, SignedValue, Value};
+use rubysys::types::{c_int, c_long, SignedValue, Value};
 
 extern "C" {
     // VALUE
@@ -6,5 +6,8 @@ extern "C" {
     pub fn rb_int2inum(num: SignedValue) -> Value;
     // long
     // rb_num2int(VALUE val)
-    pub fn rb_num2int(num: Value) -> c_long;
+    pub fn rb_num2int(num: Value) -> c_int;
+    // long
+    // rb_num2long(VALUE val)
+    pub fn rb_num2long(num: Value) -> c_long;
 }


### PR DESCRIPTION
`rb_num2int` can only handle 32bit values
for 64 bit values, we should use `rb_num2long`

For example, if you try to convert ruby Fixnum value  `1125899906842624` to  rust, you'll get:
`RangeError:  1125899906842624 integer too big to convert to `int'`
