### PR TITLE
Refactor public API of compatible_encoding

### DIFF
--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -599,7 +599,7 @@ impl EncodingSupport for RString {
     /// let string1 = RString::new_utf8("Hello");
     /// let string2 = RString::new_usascii_unchecked("Hello");
     ///
-    /// string1.compatible_encoding(&string2);
+    /// RString::compatible_encoding(&string1, &string2);
     /// ```
     ///
     /// Ruby:
@@ -614,8 +614,8 @@ impl EncodingSupport for RString {
     ///   nil
     /// end
     /// ```
-    fn compatible_encoding(&self, other: &impl Object) -> AnyObject {
-        encoding::compatible_encoding(self.value(), other.value()).into()
+    fn compatible_encoding(obj1: &impl Object, obj2: &impl Object) -> AnyObject {
+        encoding::compatible_encoding(obj1.value(), obj2.value()).into()
     }
 }
 

--- a/src/class/traits/encoding_support.rs
+++ b/src/class/traits/encoding_support.rs
@@ -6,6 +6,5 @@ pub trait EncodingSupport {
     fn force_encoding(&mut self, enc: Encoding) -> Result<Self, AnyException> where Self: Sized;
     fn is_valid_encoding(&self) -> bool;
     fn compatible_with(&self, other: &impl Object) -> bool;
-    fn compatible_encoding(&self, other: &impl Object) -> AnyObject;
+    fn compatible_encoding(obj1: &impl Object, obj2: &impl Object) -> AnyObject;
 }
-


### PR DESCRIPTION
I found that assuming the first item in the comparison, of things that needed to be compared, is a string — isn't quite helpful.