### PR TITLE
Remove Option wrapper around arguments that are passed to ruby functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn try_it(s: &str) -> String {
     let a = RString::new_utf8(s);
 
     // The `send` method returns an AnyObject type.
-    let b = a.send("reverse", None);
+    let b = a.send("reverse", &[]);
 
     // We must try to convert the AnyObject
     // type back to our usable type.

--- a/examples/rutie_ruby_gvl_example/src/lib.rs
+++ b/examples/rutie_ruby_gvl_example/src/lib.rs
@@ -61,7 +61,7 @@ methods! {
                 let class = class.clone();
                 Thread::call_with_gvl(move || {
                     let ruby_class = Class::from_existing(&class);
-                    ruby_class.send("name", None)
+                    ruby_class.send("name", &[])
                 })
             },
             Some(|| {}),
@@ -73,7 +73,7 @@ methods! {
         let (tx, rx) = mpsc::channel();
         Thread::new(move || {
             let ruby_class = Class::from_existing("Object");
-            let name = ruby_class.send("name", None);
+            let name = ruby_class.send("name", &[]);
             tx.send(name).unwrap();
             NilClass::new()
         });

--- a/examples/rutie_rust_example/Cargo.toml
+++ b/examples/rutie_rust_example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Daniel P. Clark <6ftdan@gmail.com>"]
 
 [dependencies]
-rutie = "0.5.2"
+rutie = "0.6.0"

--- a/examples/rutie_rust_example/src/main.rs
+++ b/examples/rutie_rust_example/src/main.rs
@@ -6,7 +6,7 @@ fn try_it(s: &str) -> String {
     let a = RString::new_utf8(s);
 
     // Send returns an AnyObject type
-    let b = a.send("reverse", None);
+    let b = a.send("reverse", &[]);
 
     // We must try to convert the AnyObject
     // type back to our usable type.

--- a/src/class/array.rs
+++ b/src/class/array.rs
@@ -525,7 +525,9 @@ impl Array {
     /// Enumerator === enumerator
     /// ```
     pub fn to_enum(&self) -> Enumerator {
-        self.send("to_enum", None).try_convert_to::<Enumerator>().unwrap()
+        self.send("to_enum", &[])
+            .try_convert_to::<Enumerator>()
+            .unwrap()
     }
 }
 

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -148,15 +148,15 @@ impl Class {
     /// use rutie::{Class, Fixnum, Object};
     ///
     /// // Without arguments
-    /// Class::from_existing("Hello").new_instance(None);
+    /// Class::from_existing("Hello").new_instance(&[]);
     ///
     /// // With arguments passing arguments to constructor
-    /// let arguments = [
+    /// let arguments = vec![
     ///     Fixnum::new(1).to_any_object(),
     ///     Fixnum::new(2).to_any_object()
     /// ];
     ///
-    /// Class::from_existing("Worker").new_instance(Some(&arguments));
+    /// Class::from_existing("Worker").new_instance(&arguments);
     /// ```
     ///
     /// Ruby:
@@ -166,8 +166,8 @@ impl Class {
     ///
     /// Worker.new(1, 2)
     /// ```
-    pub fn new_instance(&self, arguments: Option<&[AnyObject]>) -> AnyObject {
-        let arguments = util::arguments_to_values(arguments).unwrap_or_default();
+    pub fn new_instance(&self, arguments: &[AnyObject]) -> AnyObject {
+        let arguments = util::arguments_to_values(arguments);
         let instance = class::new_instance(self.value(), &arguments);
 
         AnyObject::from(instance)
@@ -189,7 +189,7 @@ impl Class {
     /// String.allocate
     /// ```
     pub fn allocate(&self) -> Class {
-        Class::from(self.send("allocate", None).value())
+        Class::from(self.send("allocate", &[]).value())
     }
 
     /// Returns a superclass of the current class

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -151,7 +151,7 @@ impl Class {
     /// Class::from_existing("Hello").new_instance(&[]);
     ///
     /// // With arguments passing arguments to constructor
-    /// let arguments = vec![
+    /// let arguments = [
     ///     Fixnum::new(1).to_any_object(),
     ///     Fixnum::new(2).to_any_object()
     /// ];

--- a/src/class/encoding.rs
+++ b/src/class/encoding.rs
@@ -117,7 +117,7 @@ impl Encoding {
     /// enc.name == "UTF-8"
     /// ```
     pub fn name(&self) -> String {
-        let name = self.send("name", None);
+        let name = self.send("name", &[]);
 
         RString::from(name.value()).to_string()
     }

--- a/src/class/enumerator.rs
+++ b/src/class/enumerator.rs
@@ -43,7 +43,7 @@ impl Enumerator {
     /// assert!(iter.next().is_err(), "not error!");
     /// ```
     pub fn next(&mut self) -> Result<AnyObject, AnyException> {
-        self.protect_send("next", None)
+        self.protect_send("next", &[])
     }
 
     /// Advances the iterator and returns the next values.
@@ -79,8 +79,8 @@ impl Enumerator {
     /// assert!(iter.next_values().is_err(), "not error!");
     /// ```
     pub fn next_values(&mut self) -> Result<Array, AnyException> {
-        self.protect_send("next_values", None).
-            map(|v| Array::from(v.value()) )
+        self.protect_send("next_values", &[])
+            .map(|v| Array::from(v.value()))
     }
 
     /// Peeks into the iterator and returns the next value.
@@ -100,7 +100,7 @@ impl Enumerator {
     /// assert_eq!(Ok(Fixnum::new(2).to_any_object()), iter.peek());
     /// ```
     pub fn peek(&self) -> Result<AnyObject, AnyException> {
-        self.protect_send("peek", None)
+        self.protect_send("peek", &[])
     }
 
     /// Peeks into the iterator and returns the next values.
@@ -127,8 +127,8 @@ impl Enumerator {
     /// assert_eq!(Ok(result1), iter.peek_values());
     /// ```
     pub fn peek_values(&self) -> Result<Array, AnyException> {
-        self.protect_send("peek_values", None).
-            map(|v| Array::from(v.value()) )
+        self.protect_send("peek_values", &[])
+            .map(|v| Array::from(v.value()))
     }
 
     /// Rewind the iteration back to the beginning.
@@ -156,7 +156,7 @@ impl Enumerator {
     /// assert!(iter.next().is_err(), "not error!");
     /// ```
     pub fn rewind(&mut self) -> &mut Self {
-        self.send("rewind", None);
+        self.send("rewind", &[]);
         self
     }
 
@@ -187,7 +187,7 @@ impl Enumerator {
     ///         expected.push(Fixnum::new(777).to_any_object());
     ///
     ///         assert!(Class::from_existing("StopIteration").case_equals(&e));
-    ///         assert_eq!(expected.to_any_object(), e.send("result", None));
+    ///         assert_eq!(expected.to_any_object(), e.send("result", &[]));
     ///     },
     /// }
     /// ```
@@ -209,7 +209,7 @@ impl Enumerator {
     /// end
     /// ```
     pub fn feed(&mut self, object: AnyObject) -> Result<(), AnyException> {
-        self.protect_send("feed", Some(&[object])).map(|_|())
+        self.protect_send("feed", &[object]).map(|_| ())
     }
 }
 

--- a/src/class/rproc.rs
+++ b/src/class/rproc.rs
@@ -31,7 +31,7 @@ impl Proc {
     ///
     ///     fn greet_rust_with(greeting_template: Proc) -> RString {
     ///         let name = RString::new_utf8("Rust").to_any_object();
-    ///         let rendered_template = greeting_template.unwrap().call(Some(&[name]));
+    ///         let rendered_template = greeting_template.unwrap().call(&[name]);
     ///
     ///         rendered_template.try_convert_to::<RString>().unwrap()
     ///     }
@@ -57,8 +57,8 @@ impl Proc {
     ///
     /// Greeter.greet_rust_with(greeting_template) # => "Hello, Rust!"
     /// ```
-    pub fn call(&self, arguments: Option<&[AnyObject]>) -> AnyObject {
-        let arguments = util::arguments_to_values(arguments).unwrap_or_default();
+    pub fn call(&self, arguments: &[AnyObject]) -> AnyObject {
+        let arguments = util::arguments_to_values(arguments);
         let result = rproc::call(self.value(), &arguments);
 
         AnyObject::from(result)
@@ -85,7 +85,7 @@ impl Proc {
     /// procish.lambda? # => true
     /// ```
     pub fn is_lambda(&self) -> bool {
-        Boolean::from(self.send("lambda?", None).value()).to_bool()
+        Boolean::from(self.send("lambda?", &[]).value()).to_bool()
     }
 }
 

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -557,7 +557,7 @@ impl EncodingSupport for RString {
     /// result.valid_encoding? == false
     /// ```
     fn is_valid_encoding(&self) -> bool {
-        let result = self.send("valid_encoding?", None);
+        let result = self.send("valid_encoding?", &[]);
         result.try_convert_to::<Boolean>().unwrap().to_bool()
     }
 

--- a/src/class/symbol.rs
+++ b/src/class/symbol.rs
@@ -107,7 +107,7 @@ impl Symbol {
     /// sym.to_s == 'hello'
     /// ```
     pub fn to_proc(&self) -> Proc {
-        Proc::from(self.send("to_proc", None).value())
+        Proc::from(self.send("to_proc", &[]).value())
     }
 }
 

--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -707,14 +707,14 @@ pub trait Object: From<Value> {
     /// let array = Array::new().push(Fixnum::new(1));
     /// let array_string =
     ///     array
-    ///         .send("to_s", None)
+    ///         .send("to_s", &[])
     ///         .try_convert_to::<RString>()
     ///         .unwrap();
     ///
     /// assert_eq!(array_string.to_str(), "[1]");
     /// ```
-    fn send(&self, method: &str, arguments: Option<&[AnyObject]>) -> AnyObject {
-        let arguments = util::arguments_to_values(arguments).unwrap_or_default();
+    fn send(&self, method: &str, arguments: &[AnyObject]) -> AnyObject {
+        let arguments = util::arguments_to_values(arguments);
         let result = vm::call_method(self.value(), method, &arguments);
 
         AnyObject::from(result)
@@ -885,7 +885,7 @@ pub trait Object: From<Value> {
     ///
     /// let kernel = Class::from_existing("Kernel");
     ///
-    /// let result = kernel.protect_send("nil?", None);
+    /// let result = kernel.protect_send("nil?", &[]);
     ///
     /// if let Ok(r) = result {
     ///     assert!(!r.value().is_true());
@@ -897,7 +897,7 @@ pub trait Object: From<Value> {
     ///
     /// let result = kernel.protect_send(
     ///     "raise",
-    ///     Some(&[RString::new_utf8("flowers").to_any_object()])
+    ///     &[RString::new_utf8("flowers").to_any_object()]
     /// );
     ///
     /// if let Err(error) = result {
@@ -909,8 +909,9 @@ pub trait Object: From<Value> {
     ///     unreachable!()
     /// }
     /// ```
-    fn protect_send(&self, method: &str, arguments: Option<&[AnyObject]>) -> Result<AnyObject, AnyException> {
-        let closure = || { self.send(&method, arguments).value() };
+    fn protect_send(&self, method: &str, arguments: &[AnyObject]) -> Result<AnyObject, AnyException>
+    {
+        let closure = || self.send(&method, arguments.as_ref()).value();
 
         let result = VM::protect(closure);
 
@@ -937,7 +938,7 @@ pub trait Object: From<Value> {
     ///
     /// let kernel = Class::from_existing("Kernel");
     ///
-    /// let result = kernel.protect_public_send("nil?", None);
+    /// let result = kernel.protect_public_send("nil?", &[]);
     ///
     /// if let Ok(r) = result {
     ///     assert!(!r.value().is_true());
@@ -949,7 +950,7 @@ pub trait Object: From<Value> {
     ///
     /// let result = kernel.protect_public_send(
     ///     "raise",
-    ///     Some(&[RString::new_utf8("flowers").to_any_object()])
+    ///     &[RString::new_utf8("flowers").to_any_object()]
     /// );
     ///
     /// if let Err(error) = result {
@@ -961,9 +962,13 @@ pub trait Object: From<Value> {
     ///     unreachable!()
     /// }
     /// ```
-    fn protect_public_send(&self, method: &str, arguments: Option<&[AnyObject]>) -> Result<AnyObject, AnyException> {
+    fn protect_public_send(
+        &self,
+        method: &str,
+        arguments: &[AnyObject],
+    ) -> Result<AnyObject, AnyException> {
         let v = self.value();
-        let arguments = util::arguments_to_values(arguments).unwrap_or_default();
+        let arguments = util::arguments_to_values(arguments);
 
         let closure = || {
             vm::call_public_method(v, &method, &arguments)
@@ -1018,7 +1023,7 @@ pub trait Object: From<Value> {
     /// let args = [Fixnum::new(1).to_any_object()];
     /// let index =
     ///     array
-    ///         .send("find_index", Some(&args))
+    ///         .send("find_index", &args)
     ///         .try_convert_to::<Fixnum>();
     ///
     /// assert_eq!(index, Ok(Fixnum::new(0)));
@@ -1068,11 +1073,11 @@ pub trait Object: From<Value> {
     ///         itself.def("initialize", counter_initialize);
     ///         itself.def("increment!", counter_increment);
     ///         itself.def("state", counter_state);
-    ///     }).new_instance(None);
+    ///     }).new_instance(&[]);
     ///
-    ///     counter.send("increment!", None);
+    ///     counter.send("increment!", &[]);
     ///
-    ///     let new_state = counter.send("state", None).try_convert_to::<Fixnum>();
+    ///     let new_state = counter.send("state", &[]).try_convert_to::<Fixnum>();
     ///
     ///     assert_eq!(new_state, Ok(Fixnum::new(1)));
     /// }
@@ -1149,11 +1154,11 @@ pub trait Object: From<Value> {
     ///         itself.def("initialize", counter_initialize);
     ///         itself.def("increment!", counter_increment);
     ///         itself.def("state", counter_state);
-    ///     }).new_instance(None);
+    ///     }).new_instance(&[]);
     ///
-    ///     counter.send("increment!", None);
+    ///     counter.send("increment!", &[]);
     ///
-    ///     let new_state = counter.send("state", None).try_convert_to::<Fixnum>();
+    ///     let new_state = counter.send("state", &[]).try_convert_to::<Fixnum>();
     ///
     ///     assert_eq!(new_state, Ok(Fixnum::new(1)));
     /// }

--- a/src/class/traits/verified_object.rs
+++ b/src/class/traits/verified_object.rs
@@ -103,10 +103,10 @@ use Object;
 ///
 ///     // Create new instances of classes and convert them to `AnyObject`s
 ///     // (make their type unknown)
-///     let server = Class::from_existing("Server").new_instance(None).to_any_object();
-///     let request = Class::from_existing("Request").new_instance(None).to_any_object();
-///     let response = Class::from_existing("Response").new_instance(None).to_any_object();
-///     let headers = Class::from_existing("Headers").new_instance(None).to_any_object();
+///     let server = Class::from_existing("Server").new_instance(&[]).to_any_object();
+///     let request = Class::from_existing("Request").new_instance(&[]).to_any_object();
+///     let response = Class::from_existing("Response").new_instance(&[]).to_any_object();
+///     let headers = Class::from_existing("Headers").new_instance(&[]).to_any_object();
 ///
 ///     assert!(server.try_convert_to::<Server>().is_ok());
 ///     assert!(request.try_convert_to::<Request>().is_ok());

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -298,7 +298,7 @@ impl VM {
     ///         let greeting_template = VM::block_proc();
     ///         let name = RString::new_utf8("Rust").to_any_object();
     ///
-    ///         greeting_template.call(Some(&[name])).try_convert_to::<RString>().unwrap()
+    ///         greeting_template.call(&[name]).try_convert_to::<RString>().unwrap()
     ///     }
     /// );
     ///
@@ -348,7 +348,7 @@ impl VM {
     ///
     ///         if VM::is_block_given() {
     ///             let arguments = [a.to_any_object(), b.to_any_object()];
-    ///             let result = VM::block_proc().call(Some(&arguments));
+    ///             let result = VM::block_proc().call(&arguments);
     ///
     ///             result.try_convert_to::<Fixnum>().unwrap()
     ///         } else {
@@ -515,8 +515,8 @@ impl VM {
     /// # Examples
     ///
     /// ```text
-    /// fn protect_send(&self, method: &str, arguments: Option<&[AnyObject]>) -> Result<AnyObject, AnyException> {
-    ///     let closure = || { self.send(&method, arguments).value() };
+    /// fn protect_send(&self, method: &str, arguments: &[AnyObject]) -> Result<AnyObject, AnyException> {
+    ///     let closure = || self.send(&method, arguments.as_ref()).value();
     ///
     ///     let result = VM::protect(closure);
     ///
@@ -542,8 +542,8 @@ impl VM {
     /// # Examples
     ///
     /// ```text
-    /// fn protect_send(&self, method: &str, arguments: Option<&[AnyObject]>) -> Result<AnyObject, AnyException> {
-    ///     let closure = || { self.send(&method, arguments).value() };
+    /// fn protect_send(&self, method: &str, arguments: &[AnyObject]) -> Result<AnyObject, AnyException> {
+    ///     let closure = || self.send(&method, arguments.as_ref()).value();
     ///
     ///     let result = VM::protect(closure);
     ///
@@ -566,8 +566,8 @@ impl VM {
     /// # Examples
     ///
     /// ```text
-    /// fn protect_send(&self, method: &str, arguments: Option<&[AnyObject]>) -> Result<AnyObject, AnyException> {
-    ///     let closure = || { self.send(&method, arguments).value() };
+    /// fn protect_send(&self, method: &str, arguments: &[AnyObject]) -> Result<AnyObject, AnyException> {
+    ///     let closure = || self.send(&method, arguments.as_ref()).value();
     ///
     ///     let result = VM::protect(closure);
     ///

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -770,7 +770,7 @@ macro_rules! eval {
         let bndng: $crate::AnyObject = $binding_arg.into();
         let arguments = &[eval_str, bndng];
 
-        $crate::Class::from_existing("Kernel").protect_send("eval", Some(arguments))
+        $crate::Class::from_existing("Kernel").protect_send("eval", arguments)
     }};
     ($string_arg:expr, $binding_arg:expr, $filename:expr) => {{
         let eval_str: $crate::AnyObject = $crate::RString::from($string_arg).into();
@@ -778,7 +778,7 @@ macro_rules! eval {
         let filename: $crate::AnyObject = $crate::RString::from($filename).into();
         let arguments = &[eval_str, bndng, filename];
 
-        $crate::Class::from_existing("Kernel").protect_send("eval", Some(arguments))
+        $crate::Class::from_existing("Kernel").protect_send("eval", arguments)
     }};
     ($string_arg:expr, $binding_arg:expr, $filename:expr, $linenumber:expr) => {{
         let eval_str: $crate::AnyObject = $crate::RString::from($string_arg).into();
@@ -787,6 +787,6 @@ macro_rules! eval {
         let linenumber: $crate::AnyObject = $crate::Integer::from($linenumber as i64).into();
         let arguments = &[eval_str, bndng, filename, linenumber];
 
-        $crate::Class::from_existing("Kernel").protect_send("eval", Some(arguments))
+        $crate::Class::from_existing("Kernel").protect_send("eval", arguments)
     }};
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,8 +43,8 @@ pub fn bool_to_c_int(state: bool) -> c_int {
     state as c_int
 }
 
-pub fn arguments_to_values(arguments: Option<&[AnyObject]>) -> Option<Vec<Value>> {
-    arguments.map(|arguments| arguments.iter().map(Object::value).collect())
+pub fn arguments_to_values(arguments: &[AnyObject]) -> Vec<Value> {
+    arguments.as_ref().iter().map(Object::value).collect()
 }
 
 pub fn process_arguments(arguments: &[Value]) -> (Argc, *const Value) {


### PR DESCRIPTION
Remove Option wrapper around arguments that are passed to ruby functions

Instead of passing `None` use `&[]` when no arguments are needed.


~~Since is it not possible to dynamically allocate a slice, we should
allow to pass vectors as arguments that are used to call ruby functions.~~

~~This allows to dynamically define the arguments in rust as vectors.~~

~~Due to the generic type calling those functions with no arguments (`None`)
requires to define the type for `T` even though it is not used.~~

@danielpclark What do you think about changing the signatures to this?
```rust
fn send<T>(&self, method: &str, arguments: &T) -> AnyObject
    where
        T: AsRef<[AnyObject]>
```

I think `object.send("method", &[])` would write and read nicer than `object.send::<&[AnyObject]>("method", None)`
