### PR TITLE
Enhance integer conversions

### DIFF
--- a/src/binding/fixnum.rs
+++ b/src/binding/fixnum.rs
@@ -1,15 +1,26 @@
 use rubysys::fixnum;
+use types::Value;
 
-use types::{SignedValue, Value};
-
-pub fn int_to_num(num: i64) -> Value {
-    unsafe { fixnum::rb_int2inum(num as SignedValue) }
+pub fn i32_to_num(num: i32) -> Value {
+    unsafe { fixnum::rb_int2inum(num as isize) }
 }
 
-pub fn num_to_int(num: Value) -> i32 {
-    unsafe { fixnum::rb_num2int(num) }
+pub fn i64_to_num(num: i64) -> Value {
+    unsafe { fixnum::rb_ll2inum(num) }
 }
 
-pub fn num_to_long(num: Value) -> i64 {
-    unsafe { fixnum::rb_num2long(num) }
+pub fn u64_to_num(num: u64) -> Value {
+    unsafe { fixnum::rb_ull2inum(num) }
+}
+
+pub fn num_to_i32(num: Value) -> i32 {
+    unsafe { fixnum::rb_num2int(num) as i32 }
+}
+
+pub fn num_to_i64(num: Value) -> i64 {
+    unsafe { fixnum::rb_num2ll(num) }
+}
+
+pub fn num_to_u64(num: Value) -> u64 {
+    unsafe { fixnum::rb_num2ull(num) }
 }

--- a/src/binding/fixnum.rs
+++ b/src/binding/fixnum.rs
@@ -5,6 +5,18 @@ pub fn i32_to_num(num: i32) -> Value {
     unsafe { fixnum::rb_int2inum(num as isize) }
 }
 
+pub fn u32_to_num(num: u32) -> Value {
+    unsafe { fixnum::rb_uint2inum(num as usize) }
+}
+
+pub fn isize_to_num(num: isize) -> Value {
+    unsafe { fixnum::rb_int2inum(num) }
+}
+
+pub fn usize_to_num(num: usize) -> Value {
+    unsafe { fixnum::rb_uint2inum(num) }
+}
+
 pub fn i64_to_num(num: i64) -> Value {
     unsafe { fixnum::rb_ll2inum(num) }
 }
@@ -15,6 +27,18 @@ pub fn u64_to_num(num: u64) -> Value {
 
 pub fn num_to_i32(num: Value) -> i32 {
     unsafe { fixnum::rb_num2int(num) as i32 }
+}
+
+pub fn num_to_u32(num: Value) -> u32 {
+    unsafe { fixnum::rb_num2uint(num) as u32 }
+}
+
+pub fn num_to_isize(num: Value) -> isize {
+    unsafe { fixnum::rb_num2long(num) as isize }
+}
+
+pub fn num_to_usize(num: Value) -> usize {
+    unsafe { fixnum::rb_num2ulong(num) as usize }
 }
 
 pub fn num_to_i64(num: Value) -> i64 {

--- a/src/binding/hash.rs
+++ b/src/binding/hash.rs
@@ -32,7 +32,7 @@ pub fn length(hash: Value) -> i64 {
     unsafe {
         let size = hash::rb_hash_size(hash);
 
-        fixnum::num_to_long(size)
+        fixnum::num_to_i64(size)
     }
 }
 

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -31,7 +31,7 @@ impl Fixnum {
     /// 1 == 1
     /// ```
     pub fn new(num: i64) -> Self {
-        Self::from(fixnum::int_to_num(num))
+        Self::from(fixnum::i64_to_num(num))
     }
 
     /// Retrieves an `i64` value from `Fixnum`.
@@ -53,7 +53,29 @@ impl Fixnum {
     /// 1 == 1
     /// ```
     pub fn to_i64(&self) -> i64 {
-        fixnum::num_to_long(self.value())
+        fixnum::num_to_i64(self.value())
+    }
+
+    /// Retrieves an `u64` value from `Fixnum`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Fixnum, VM};
+    /// # VM::init();
+    ///
+    /// let fixnum = Fixnum::new(1);
+    ///
+    /// assert_eq!(fixnum.to_u64(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_u64(&self) -> u64 {
+        fixnum::num_to_u64(self.value())
     }
 
     /// Retrieves an `i32` value from `Fixnum`.
@@ -75,7 +97,7 @@ impl Fixnum {
     /// 1 == 1
     /// ```
     pub fn to_i32(&self) -> i32 {
-        fixnum::num_to_int(self.value())
+        fixnum::num_to_i32(self.value())
     }
 }
 

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -131,9 +131,27 @@ impl Into<u64> for Integer {
     }
 }
 
+impl From<i32> for Integer {
+    fn from(num: i32) -> Self {
+        Integer { value: fixnum::i32_to_num(num) }
+    }
+}
+
 impl Into<i32> for Integer {
     fn into(self) -> i32 {
         fixnum::num_to_i32(self.value())
+    }
+}
+
+impl From<u32> for Integer {
+    fn from(num: u32) -> Self {
+        Integer { value: fixnum::u32_to_num(num) }
+    }
+}
+
+impl Into<u32> for Integer {
+    fn into(self) -> u32 {
+        fixnum::num_to_u32(self.value())
     }
 }
 

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -53,7 +53,29 @@ impl Integer {
     /// 1 == 1
     /// ```
     pub fn to_i64(&self) -> i64 {
-        fixnum::num_to_long(self.value())
+        fixnum::num_to_i64(self.value())
+    }
+
+    /// Retrieves an `u64` value from `Integer`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Integer, VM};
+    /// # VM::init();
+    ///
+    /// let integer = Integer::new(1);
+    ///
+    /// assert_eq!(integer.to_u64(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_u64(&self) -> u64 {
+        fixnum::num_to_u64(self.value())
     }
 
     /// Retrieves an `i32` value from `Integer`.
@@ -75,7 +97,7 @@ impl Integer {
     /// 1 == 1
     /// ```
     pub fn to_i32(&self) -> i32 {
-        fixnum::num_to_int(self.value())
+        fixnum::num_to_i32(self.value())
     }
 }
 
@@ -87,19 +109,31 @@ impl From<Value> for Integer {
 
 impl From<i64> for Integer {
     fn from(num: i64) -> Self {
-        Integer { value: fixnum::int_to_num(num) }
+        Integer { value: fixnum::i64_to_num(num) }
     }
 }
 
 impl Into<i64> for Integer {
     fn into(self) -> i64 {
-        fixnum::num_to_long(self.value())
+        fixnum::num_to_i64(self.value())
+    }
+}
+
+impl From<u64> for Integer {
+    fn from(num: u64) -> Self {
+        Integer { value: fixnum::u64_to_num(num) }
+    }
+}
+
+impl Into<u64> for Integer {
+    fn into(self) -> u64 {
+        fixnum::num_to_u64(self.value())
     }
 }
 
 impl Into<i32> for Integer {
     fn into(self) -> i32 {
-        fixnum::num_to_int(self.value())
+        fixnum::num_to_i32(self.value())
     }
 }
 

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -164,7 +164,8 @@ impl Object for Integer {
 
 impl VerifiedObject for Integer {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.value().ty() == ValueType::Fixnum
+        let ty = object.value().ty();
+        ty == ValueType::Fixnum || ty == ValueType::Bignum
     }
 
     fn error_message() -> &'static str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,22 @@ pub use class::traits::try_convert::TryConvert;
 
 pub use helpers::codepoint_iterator::CodepointIterator;
 
+use std::sync::{Arc, RwLock};
+
+#[cfg(test)]
+lazy_static! {
+    pub static ref LOCK_FOR_TEST: RwLock<i32> = RwLock::new(0);
+}
+
 #[cfg(test)]
 mod current_ruby {
+    use super::*;
     use std::process::Command;
     use super::{Object, RString, VM};
 
     #[test]
     fn is_linked_ruby() {
+        let _guard = LOCK_FOR_TEST.write().unwrap();
         VM::init();
        
         let rv = RString::from(VM::eval("RUBY_VERSION").unwrap().value()).to_string();

--- a/src/rubysys/fixnum.rs
+++ b/src/rubysys/fixnum.rs
@@ -1,13 +1,42 @@
-use rubysys::types::{c_int, c_long, SignedValue, Value};
+use rubysys::libc;
+use rubysys::types::Value;
 
 extern "C" {
     // VALUE
     // rb_int2inum(intptr_t n)
-    pub fn rb_int2inum(num: SignedValue) -> Value;
+    pub fn rb_int2inum(num: libc::intptr_t) -> Value;
+    // VALUE
+    // rb_uint2inum(uintptr_t n)
+    pub fn rb_uint2inum(num: libc::uintptr_t) -> Value;
+    // VALUE
+    // rb_ll2inum(LONG_LONG n)
+    pub fn rb_ll2inum(num: libc::c_longlong) -> Value;
+    // VALUE
+    // rb_ull2inum(unsigned LONG_LONG n)
+    pub fn rb_ull2inum(num: libc::c_ulonglong) -> Value;
+
+    // short
+    // rb_num2short(VALUE val)
+    pub fn rb_num2short(num: Value) -> libc::c_short;
+    // unsigned short
+    // rb_num2ushort(VALUE val)
+    pub fn rb_num2ushort(num: Value) -> libc::c_ushort;
     // long
     // rb_num2int(VALUE val)
-    pub fn rb_num2int(num: Value) -> c_int;
+    pub fn rb_num2int(num: Value) -> libc::c_long;
+    // unsigned long
+    // rb_num2uint(VALUE val)
+    pub fn rb_num2uint(num: Value) -> libc::c_ulong;
     // long
     // rb_num2long(VALUE val)
-    pub fn rb_num2long(num: Value) -> c_long;
+    pub fn rb_num2long(num: Value) -> libc::c_long;
+    // unsigned long
+    // rb_num2ulong(VALUE val)
+    pub fn rb_num2ulong(num: Value) -> libc::c_ulong;
+    // LONG_LONG
+    // rb_num2ll(VALUE val)
+    pub fn rb_num2ll(num: Value) -> libc::c_longlong;
+    // unsigned LONG_LONG
+    // rb_num2ull(VALUE val)
+    pub fn rb_num2ull(num: Value) -> libc::c_ulonglong;
 }


### PR DESCRIPTION
This pull request contains several fixes. Please let me know if it is better to split.

* `Integer` type now supports Ruby's `Bignum`
* Rename `num_to_int` to `num_to_i32`. etc.
    * It's difficult to understand the type of C. For example, `long` corresponds to `isize` instead of `i64`
* Add test for `Integer`
    * It is just to check the behavior of Ruby's implementation.
* Add `LOCK_FOR_TEST` global variable.
    * Rust's test works in parallel using threads, but unfortunately it seems that it doesn't work properly if we run Ruby in parallel.


