### PR TITLE
check if libruby symlink exists before attempting to create one in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -177,7 +177,12 @@ fn ruby_lib_link_name() -> String {
     let source = format!("{}/{}", rbconfig("libdir"), so_file);
     let target = format!("{}/{}", destination, so_file);
 
-    if !Path::new(&target).exists() {
+    let sym_link_exists = match fs::read_link(&target) {
+        Ok(_) => true,
+        _ => false
+    };
+
+    if ! sym_link_exists {
         let _ = symlink(source, target).expect("symlink fail");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::process::Command;
-use std::path::{Path, PathBuf};
+use std::path::{PathBuf};
 use std::env;
 
 #[cfg(not(target_os = "macos"))]
@@ -177,12 +177,7 @@ fn ruby_lib_link_name() -> String {
     let source = format!("{}/{}", rbconfig("libdir"), so_file);
     let target = format!("{}/{}", destination, so_file);
 
-    let sym_link_exists = match fs::read_link(&target) {
-        Ok(_) => true,
-        _ => false
-    };
-
-    if ! sym_link_exists {
+    if fs::read_link(&target).is_err() {
         let _ = symlink(source, target).expect("symlink fail");
     }
 


### PR DESCRIPTION
I've noticed on Linux that if the symlink for libruby already exists in the `~/.cargo/registry/src/.../rutie/target/release/deps` folder and you rebuild a project with rutie as a dependency you will get the following error:

```
thread 'main' panicked at 'symlink fail: Os { code: 17, kind: AlreadyExists, message: "File exists" }', src/libcore/result.rs:997:5
```

Steps to reproduce:
1) `cargo build` a project with Rutie as a dependency
2) Perform either `cargo clean && cargo build` or update your version of Rust via rustup. 

Unfortunately `cargo clean` doesn't clean the contents of `~/.cargo/registry/src`. As a workaround you can just delete the symlink present in the deps folder. However, this isn't easily achievable when deploying to Heroku. I primarily see this error when a new version of Rust is released and the Heroku buildpack updates its version of Rust, which triggers a rebuild of the project, but doesn't update the contents of `~./cargo/registry/src`.

According to the [documentation](https://doc.rust-lang.org/std/path/struct.Path.html#method.exists) for `.exists()` it should only return false on a broken symlink, but it is definitely returning false on Ubuntu 19.04 with Rust 1.34.1, and on Heroku's stack which is also running Ubuntu. 

This change will explicitly check for a symlink in target location. As I understand the [documentation](https://doc.rust-lang.org/std/fs/fn.read_link.html) read_link should only return `Ok` if the path is a symlink. Otherwise, it's an error.