### PR TITLE
preventative action on examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,20 +40,21 @@ matrix:
       env: RUBY_THREADING=true BUILD_RUBY_VERSION=2.6.3
       script:
         - |
+          export WORKING_DIR=`pwd`
           echo "Running Eval Example"
           cargo run --example eval "a=5;b=9;puts a+b"
           echo "Running Ruby Example"
-          cd "$HOME/examples/rutie_ruby_example"
+          cd "$WORKING_DIR/examples/rutie_ruby_example"
           gem install bundler
           bundle install
           bundle exec rake
           echo "Running Ruby GVL Example"
-          cd "$HOME/examples/rutie_ruby_gvl_example"
+          cd "$WORKING_DIR/examples/rutie_ruby_gvl_example"
           gem install bundler
           bundle install
           bundle exec rake
           echo "Running Rust Example"
-          cd "$HOME/examples/rutie_rust_example"
+          cd "$WORKING_DIR/examples/rutie_rust_example"
           cargo test
     - os: linux
       rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,21 @@ matrix:
       env: RUBY_THREADING=true BUILD_RUBY_VERSION=2.6.3
       script:
         - |
-          cd examples/rutie_ruby_gvl_example
-          gem uninstall bundler -ax
-          gem install bundler -v 1.17.3
+          echo "Running Eval Example"
+          cargo run --example eval "a=5;b=9;puts a+b"
+          echo "Running Ruby Example"
+          cd "$HOME/examples/rutie_ruby_example"
+          gem install bundler
           bundle install
           bundle exec rake
+          echo "Running Ruby GVL Example"
+          cd "$HOME/examples/rutie_ruby_gvl_example"
+          gem install bundler
+          bundle install
+          bundle exec rake
+          echo "Running Rust Example"
+          cd "$HOME/examples/rutie_rust_example"
+          cargo test
     - os: linux
       rust: stable
       env: RUBY_STATIC=true BUILD_RUBY_VERSION=2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ matrix:
           bundle exec rake
           echo "Running Rust Example"
           cd "$WORKING_DIR/examples/rutie_rust_example"
+          export LD_LIBRARY_PATH=`ruby -e "puts RbConfig::CONFIG['libdir']"`
+          export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
           cargo test
     - os: linux
       rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,28 @@ matrix:
           echo "Running Rust Example"
           cd "$WORKING_DIR/examples/rutie_rust_example"
           export LD_LIBRARY_PATH=`ruby -e "puts RbConfig::CONFIG['libdir']"`
-          export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+          cargo test
+    - os: osx
+      rust: stable
+      env: RUBY_THREADING=true BUILD_RUBY_VERSION=2.6.3
+      script:
+        - |
+          export WORKING_DIR=`pwd`
+          echo "Running Eval Example"
+          cargo run --example eval "a=5;b=9;puts a+b"
+          echo "Running Ruby Example"
+          cd "$WORKING_DIR/examples/rutie_ruby_example"
+          gem install bundler
+          bundle install
+          bundle exec rake
+          echo "Running Ruby GVL Example"
+          cd "$WORKING_DIR/examples/rutie_ruby_gvl_example"
+          gem install bundler
+          bundle install
+          bundle exec rake
+          echo "Running Rust Example"
+          cd "$WORKING_DIR/examples/rutie_rust_example"
+          export DYLD_LIBRARY_PATH=`ruby -e "puts RbConfig::CONFIG['libdir']"`
           cargo test
     - os: linux
       rust: stable

--- a/examples/rutie_ruby_example/Rakefile
+++ b/examples/rutie_ruby_example/Rakefile
@@ -2,6 +2,14 @@ require "rbconfig"
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+# Mac OS with rbenv users keep leaving behind build artifacts from
+#   when they tried to build against a statically linked Ruby and then
+#   try against a dynamically linked one causing errors in the build result.
+desc 'Preventative work'
+task :tidy_up do
+  sh 'cargo clean'
+end
+
 desc 'Build Rust extension'
 task :build_lib do
   case RbConfig::CONFIG['host_os']
@@ -17,7 +25,7 @@ task :bundle_install do
   sh 'bundle install'
 end
 
-Rake::TestTask.new(test: [:bundle_install, :build_lib]) do |t|
+Rake::TestTask.new(test: [:tidy_up, :bundle_install, :build_lib]) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]

--- a/examples/rutie_ruby_example/rutie_ruby_example.gemspec
+++ b/examples/rutie_ruby_example/rutie_ruby_example.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rutie", "~> 0.0.3"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/examples/rutie_ruby_gvl_example/Rakefile
+++ b/examples/rutie_ruby_gvl_example/Rakefile
@@ -2,6 +2,14 @@ require "rbconfig"
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+# Mac OS with rbenv users keep leaving behind build artifacts from
+#   when they tried to build against a statically linked Ruby and then
+#   try against a dynamically linked one causing errors in the build result.
+desc 'Preventative work'
+task :tidy_up do
+  sh 'cargo clean'
+end
+
 desc 'Build Rust extension'
 task :build_lib do
   case RbConfig::CONFIG['host_os']
@@ -12,7 +20,12 @@ task :build_lib do
   end
 end
 
-Rake::TestTask.new(test: :build_lib) do |t|
+desc 'bundle install'
+task :bundle_install do
+  sh 'bundle install'
+end
+
+Rake::TestTask.new(test: [:tidy_up, :bundle_install, :build_lib]) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]

--- a/examples/rutie_ruby_gvl_example/rutie_ruby_gvl_example.gemspec
+++ b/examples/rutie_ruby_gvl_example/rutie_ruby_gvl_example.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rutie", "~> 0.0.3"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/examples/rutie_rust_example/Cargo.toml
+++ b/examples/rutie_rust_example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Daniel P. Clark <6ftdan@gmail.com>"]
 
 [dependencies]
-rutie = "=0.6.0-rc2"
+rutie = "=0.6.0-rc.2"

--- a/examples/rutie_rust_example/Cargo.toml
+++ b/examples/rutie_rust_example/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Daniel P. Clark <6ftdan@gmail.com>"]
 
 [dependencies]
-rutie = "0.6.0"
+rutie = "=0.6.0-rc2"


### PR DESCRIPTION
Users are running in to issues with examples because of old build artifacts so add `cargo clean` to the rake command.  Also have CI test all examples.  And add env for Rust example as is in the README.