### PR TITLE
Correctly handle Float conversion of Ruby numerics

### DIFF
--- a/src/class/float.rs
+++ b/src/class/float.rs
@@ -84,7 +84,11 @@ impl Object for Float {
 
 impl VerifiedObject for Float {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.value().ty() == ValueType::Float
+        let ty = object.value().ty();
+        ty == ValueType::Float
+            || ty == ValueType::Fixnum
+            || ty == ValueType::Bignum
+            || ty == ValueType::Rational
     }
 
     fn error_message() -> &'static str {
@@ -95,5 +99,41 @@ impl VerifiedObject for Float {
 impl PartialEq for Float {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::types::Value;
+    use super::super::super::{AnyException, Float, Object, LOCK_FOR_TEST, VM};
+
+    #[test]
+    fn test_numeric_conversion() {
+        let _guard = LOCK_FOR_TEST.write().unwrap();
+        VM::init();
+
+        let fixnum = eval_to_float("-81927").unwrap();
+        assert_eq!(fixnum.to_f64(), -81927.0);
+
+        let bignum = eval_to_float("2 ** 62").unwrap();
+        assert_eq!(bignum.to_f64(), 4611686018427387904.0);
+
+        let float = eval_to_float("123456789.0").unwrap();
+        assert_eq!(float.to_f64(), 123456789.0);
+
+        let rational = eval_to_float("1/2r").unwrap();
+        assert_eq!(rational.to_f64(), 0.5);
+
+        let rational_repeating = eval_to_float("-1/3r").unwrap();
+        assert_eq!(rational_repeating.to_f64(), -0.3333333333333333);
+
+        let string = eval_to_float("'5.0'");
+        assert!(string.is_err());
+
+        VM::exit(0);
+    }
+
+    fn eval_to_float(code: &str) -> Result<Float, AnyException> {
+        VM::eval(code).and_then(|x| x.try_convert_to::<Float>())
     }
 }


### PR DESCRIPTION
This PR fixes #99 that I reported yesterday. 

It adds support for Ruby's other numeric types `Fixnum`, `Bignum`, and `Rational`, which can be automatically cast by the Ruby CPI to a `Float`. I did not add `Complex` support, because it's not 100% safe (e.g. `Complex(1, 1)` cannot be cast to a Float).

Result:

```rust
fn rutie_float_test(base: Float) -> Float {
  Float::new(base.unwrap().to_f64() * 2.0)
}
```

```ruby
# Before this patch
RutieExample.rutie_float_test(10)
# PANIC!! 💀

# Before this patch
RutieExample.rutie_float_test(1/2r)
# PANIC!! 💀

# After this patch
RutieExample.rutie_float_test(10) 
# => 20 😎
```