### PR TITLE
return st_retval from rb_hash_foreach

### DIFF
--- a/src/binding/hash.rs
+++ b/src/binding/hash.rs
@@ -36,7 +36,7 @@ pub fn length(hash: Value) -> i64 {
     }
 }
 
-use util::callback_call::two_parameters as each_callback;
+use util::callback_call::hash_foreach_callback as each_callback;
 
 pub fn each<F>(hash: Value, closure_callback: F)
 where
@@ -45,6 +45,6 @@ where
     let closure_ptr = &closure_callback as *const _ as CallbackMutPtr;
 
     unsafe {
-        hash::rb_hash_foreach(hash, each_callback::<F, AnyObject, AnyObject, ()> as CallbackPtr, closure_ptr);
+        hash::rb_hash_foreach(hash, each_callback::<F, AnyObject, AnyObject> as CallbackPtr, closure_ptr);
     }
 }

--- a/src/class/hash.rs
+++ b/src/class/hash.rs
@@ -306,3 +306,35 @@ impl PartialEq for Hash {
         self.equals(other)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{LOCK_FOR_TEST, Fixnum, Hash, Object, Symbol, VM};
+
+    #[test]
+    fn test_hash_each() {
+        let _guard = LOCK_FOR_TEST.write().unwrap();
+        VM::init();
+
+        let mut hash = Hash::new();
+
+        let len: i64 = 200;
+
+        for i in 0..len {
+            hash.store(Symbol::new(&format!("key_{}", i)), Fixnum::new(i));
+        }
+
+        assert_eq!(hash.length(), len as usize);
+
+        let mut counter: i64 = 0;
+
+        hash.each(|k, v| {
+            assert_eq!(k.try_convert_to::<Symbol>().map(|s| s.to_string()), Ok(format!("key_{}", counter)));
+            assert_eq!(v.try_convert_to::<Fixnum>().map(|f| f.to_i64()), Ok(counter));
+
+            counter += 1;
+        });
+
+        assert_eq!(counter, len);
+    }
+}

--- a/src/rubysys/types.rs
+++ b/src/rubysys/types.rs
@@ -33,3 +33,12 @@ pub struct RBasic {
     pub flags: InternalValue,
     pub klass: InternalValue,
 }
+
+#[repr(C)]
+pub enum st_retval {
+    Continue,
+    Stop,
+    Delete,
+    Check,
+    Replace,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,8 @@
 use AnyObject;
 
-pub use rubysys::types::{c_char, c_int, c_long, c_void, size_t, Argc, CallbackMutPtr, CallbackPtr,
-                          Id, InternalValue, RbDataType as DataType, EncodingIndex, EncodingType,
-                          RbDataTypeFunction as DataTypeFunction, SignedValue, Value, ValueType,
-                          VmPointer};
+pub use rubysys::types::{c_char, c_int, c_long, c_void, size_t, st_retval, Argc, CallbackMutPtr, CallbackPtr,
+                         EncodingIndex, EncodingType, Id, InternalValue, RbDataType as DataType,
+                         RbDataTypeFunction as DataTypeFunction, SignedValue, Value, ValueType, VmPointer};
 
 #[cfg(unix)]
 pub use rubysys::types::RawFd;

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,7 +124,7 @@ pub fn inmost_rb_object(klass: &str) -> Value {
 }
 
 pub mod callback_call {
-    use ::types::{c_void, CallbackMutPtr};
+    use ::types::{c_void, CallbackMutPtr, st_retval};
 
     pub fn no_parameters<F: FnMut() -> R, R>(ptr: CallbackMutPtr) -> R {
         let f = ptr as *mut F;
@@ -136,8 +136,9 @@ pub mod callback_call {
         unsafe { (*f)(a) }
     }
 
-    pub fn two_parameters<F: FnMut(A, B) -> R, A, B, R>(a: A, b: B, ptr: CallbackMutPtr) -> R {
+    pub fn hash_foreach_callback<F: FnMut(A, B), A, B>(a: A, b: B, ptr: CallbackMutPtr) -> st_retval {
         let f = ptr as *mut F;
-        unsafe { (*f)(a, b) }
+        unsafe { (*f)(a, b); }
+        st_retval::Continue
     }
 }


### PR DESCRIPTION
`rb_hash_foreach` wants a callback that returns an `st_retval`.

Returning `()` causes (AFAICT?) a read from uninitialized memory, which means who-knows-what happens when iterating. I wasn't able to reduce this to a repeatable test case, but I have been able to observe this happening in real code, and this commit does appear to fix it.

I've hard coded a return of `st_retval::Continue` so as to not break the current API, but maybe `rutie::Hash` should have a new method that allows controlling it.