### PR TITLE
Fix build warnings from bare trait objects

### DIFF
--- a/src/binding/class.rs
+++ b/src/binding/class.rs
@@ -101,13 +101,13 @@ pub fn define_singleton_method<I: Object, O: Object>(
     }
 }
 
-pub fn wrap_data<T>(klass: Value, data: T, wrapper: &DataTypeWrapper<T>) -> Value {
+pub fn wrap_data<T>(klass: Value, data: T, wrapper: &dyn DataTypeWrapper<T>) -> Value {
     let data = Box::into_raw(Box::new(data)) as *mut c_void;
 
     unsafe { typed_data::rb_data_typed_object_wrap(klass, data, wrapper.data_type()) }
 }
 
-pub fn get_data<T>(object: Value, wrapper: &DataTypeWrapper<T>) -> &mut T {
+pub fn get_data<T>(object: Value, wrapper: &dyn DataTypeWrapper<T>) -> &mut T {
     unsafe {
         let data = typed_data::rb_check_typeddata(object, wrapper.data_type());
 

--- a/src/binding/thread.rs
+++ b/src/binding/thread.rs
@@ -15,7 +15,7 @@ where
     F: FnMut() -> R,
     R: Object,
 {
-    let fnbox = Box::new(func) as Box<FnMut() -> R>;
+    let fnbox = Box::new(func) as Box<dyn FnMut() -> R>;
 
     let closure_ptr = Box::into_raw(Box::new(fnbox)) as CallbackMutPtr;
 
@@ -97,15 +97,15 @@ extern "C" fn thread_create_callbox<R>(boxptr: CallbackMutPtr) -> Value
 where
     R: Object,
 {
-    let mut fnbox: Box<Box<FnMut() -> R>> =
-        unsafe { Box::from_raw(boxptr as *mut Box<FnMut() -> R>) };
+    let mut fnbox: Box<Box<dyn FnMut() -> R>> =
+        unsafe { Box::from_raw(boxptr as *mut Box<dyn FnMut() -> R>) };
 
     fnbox().value()
 }
 
 extern "C" fn thread_call_callbox(boxptr: CallbackMutPtr) -> CallbackPtr {
-    let mut fnbox: Box<Box<FnMut() -> CallbackPtr>> =
-        unsafe { Box::from_raw(boxptr as *mut Box<FnMut() -> CallbackPtr>) };
+    let mut fnbox: Box<Box<dyn FnMut() -> CallbackPtr>> =
+        unsafe { Box::from_raw(boxptr as *mut Box<dyn FnMut() -> CallbackPtr>) };
 
     fnbox()
 }

--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -171,8 +171,8 @@ where
 }
 
 extern "C" fn callbox(boxptr: *mut c_void) -> *const c_void {
-    let mut fnbox: Box<Box<FnMut() -> *const c_void>> =
-        unsafe { Box::from_raw(boxptr as *mut Box<FnMut() -> *const c_void>) };
+    let mut fnbox: Box<Box<dyn FnMut() -> *const c_void>> =
+        unsafe { Box::from_raw(boxptr as *mut Box<dyn FnMut() -> *const c_void>) };
 
     fnbox()
 }

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -690,7 +690,7 @@ impl Class {
     /// server.host == "127.0.0.1"
     /// server.port == 3000
     /// ```
-    pub fn wrap_data<T, O: Object>(&self, data: T, wrapper: &DataTypeWrapper<T>) -> O {
+    pub fn wrap_data<T, O: Object>(&self, data: T, wrapper: &dyn DataTypeWrapper<T>) -> O {
         let value = class::wrap_data(self.value(), data, wrapper);
 
         O::from(value)

--- a/src/class/module.rs
+++ b/src/class/module.rs
@@ -721,7 +721,7 @@ impl Module {
     /// server.host == "127.0.0.1"
     /// server.port == 3000
     /// ```
-    pub fn wrap_data<T, O: Object>(&self, data: T, wrapper: &DataTypeWrapper<T>) -> O {
+    pub fn wrap_data<T, O: Object>(&self, data: T, wrapper: &dyn DataTypeWrapper<T>) -> O {
         let value = class::wrap_data(self.value(), data, wrapper);
 
         O::from(value)

--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -205,12 +205,12 @@ pub trait Object: From<Value> {
     /// server.host == "127.0.0.1"
     /// server.port == 3000
     /// ```
-    fn get_data<'a, T>(&'a self, wrapper: &'a DataTypeWrapper<T>) -> &T {
+    fn get_data<'a, T>(&'a self, wrapper: &'a dyn DataTypeWrapper<T>) -> &T {
         class::get_data(self.value(), wrapper)
     }
 
     /// Gets a mutable reference to the Rust structure which is wrapped into a Ruby object.
-    fn get_data_mut<'a, T>(&'a mut self, wrapper: &'a DataTypeWrapper<T>) -> &mut T {
+    fn get_data_mut<'a, T>(&'a mut self, wrapper: &'a dyn DataTypeWrapper<T>) -> &mut T {
         class::get_data(self.value(), wrapper)
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -97,7 +97,7 @@ where
         Box::into_raw(Box::new(r)) as *const c_void
     };
 
-    let fnbox = Box::new(wrap_return) as Box<FnMut() -> *const c_void>;
+    let fnbox = Box::new(wrap_return) as Box<dyn FnMut() -> *const c_void>;
 
     Box::into_raw(Box::new(fnbox)) as *const c_void
 }


### PR DESCRIPTION
The warning is "trait objects without an explicit `dyn` are deprecated" and is easily fixed: https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html