### PR TITLE
add "no-link" cargo feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ API and may have breaking changes during a teeny version change.
 
 
 ## [Unreleased]
+### Added
+- cargo feature `no-link` disables linking to `libruby`, thanks to @danlarkin
 
 ## [0.7.0] - 2019-08-19
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ license = "MIT"
 build = "build.rs"
 links = "ruby"
 
+[features]
+no-link = [] # tells build.rs to not link to libruby
+
 [dependencies]
 libc = "0.2.58"
 lazy_static = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ file. Add Rutie to the `Cargo.toml` file and define the lib type.
 
 ```toml
 [dependencies]
-rutie = "0.6.1"
+rutie = {version="xxx", features=["no-link"]}
 
 [lib]
 name = "rutie_ruby_example"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 ```
 
 Then edit your `src/lib.rs` file for your Rutie code.
@@ -361,9 +361,18 @@ before using Ruby code from Rust.
 
 #### Error while loading shared libraries: libruby.so.#.#: cannot open shared object file: No such file or directory
 
-This may happen when a Ruby program is trying to link with libruby via Rutie.  Simply disable linking
-by setting the environment variable `NO_LINK_RUTIE` before the Rust code is compiled.  This is needed
-to be done on the service TravisCI for example.
+This happens when the Rutie build is trying to link with `libruby`,
+but it's not found on your library search path. Either add it to
+`LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` if you're building a standalone
+program that calls `VM::init()`, or if you're building a library to
+load into a running Ruby VM then you can disable linking by either
+setting the environment variable `NO_LINK_RUTIE`, or enabling the
+cargo feature `no-link` for Rutie in your `Cargo.toml` like this:
+
+```toml
+[dependencies]
+rutie = {version="xxx", features=["no-link"]}
+```
 
 #### Calling methods from other methods within the `methods!` macro doesn't work
 

--- a/build.rs
+++ b/build.rs
@@ -343,9 +343,14 @@ fn is_static() -> bool {
     env::var_os("RUBY_STATIC").is_some()
 }
 
+fn should_link() -> bool {
+    std::env::var_os("NO_LINK_RUTIE").is_none()
+        && std::env::var_os("CARGO_FEATURE_NO_LINK").is_none()
+}
+
 fn main() {
     // Ruby programs calling Rust doesn't need cc linking
-    if let None = std::env::var_os("NO_LINK_RUTIE") {
+    if should_link() {
 
         // If windows OS do windows stuff
         windows_support();


### PR DESCRIPTION
Using a cargo feature is a bit easier for projects that never want to link to `libruby` - like those building a ruby extension in rust.