### PR TITLE
Add faster versions of `equals`, `is_eql` and `is_equal`

### DIFF
--- a/src/binding/class.rs
+++ b/src/binding/class.rs
@@ -122,3 +122,11 @@ pub fn is_frozen(object: Value) -> Value {
 pub fn freeze(object: Value) -> Value {
     unsafe { class::rb_obj_freeze(object) }
 }
+
+pub fn is_eql(object1: Value, object2: Value) -> Value {
+    unsafe { class::rb_eql(object1, object2) }
+}
+
+pub fn equals(object1: Value, object2: Value) -> Value {
+    unsafe { class::rb_equal(object1, object2) }
+}

--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -745,11 +745,7 @@ pub trait Object: From<Value> {
     /// a == c # true
     /// ```
     fn equals<T: Object>(&self, other: &T) -> bool {
-        let v = self.value();
-        let m = "==";
-        let a = [other.value()];
-
-        vm::call_method(v, m, &a).is_true()
+        class::equals(self.value(), other.value()).is_true()
     }
 
     /// Alias for Ruby's `===`
@@ -811,11 +807,7 @@ pub trait Object: From<Value> {
     /// a.eql?(c)
     /// ```
     fn is_eql<T: Object>(&self, other: &T) -> bool {
-        let v = self.value();
-        let m = "eql?";
-        let a = [other.value()];
-
-        vm::call_method(v, m, &a).is_true()
+        class::is_eql(self.value(), other.value()).is_true()
     }
 
     /// Alias for Ruby's `equal?`
@@ -846,11 +838,7 @@ pub trait Object: From<Value> {
     /// a.eqlua?(c)
     /// ```
     fn is_equal<T: Object>(&self, other: &T) -> bool {
-        let v = self.value();
-        let m = "equal?";
-        let a = [other.value()];
-
-        vm::call_method(v, m, &a).is_true()
+        self.value() == other.value()
     }
 
     /// Checks whether the object responds to given method

--- a/src/rubysys/class.rs
+++ b/src/rubysys/class.rs
@@ -43,6 +43,12 @@ extern "C" {
                                       name: *const c_char,
                                       callback: CallbackPtr,
                                       argc: Argc);
+    // VALUE
+    // rb_eql(VALUE obj1, VALUE obj2)
+    pub fn rb_eql(obj1: Value, obj2: Value) -> Value;
+    // VALUE
+    // rb_equal(VALUE obj1, VALUE obj2)
+    pub fn rb_equal(obj1: Value, obj2: Value) -> Value;
     // void
     // rb_extend_object(VALUE object, VALUE module)
     pub fn rb_extend_object(object: Value, module: Value);


### PR DESCRIPTION
Hi there,

I'm just getting my feet wet with Rust/Rutie, so its entirely possible that this patch is nonsensical.  Also, I'm not sure if I have put things in the right place, etc. Happy to make any changes you consider necessary!

The changes are:

- `Object::equals` is now a wrapper around the `rb_equal` C function;
- `Object::is_eql` is now a wrapper around the `rb_eql` C function;
- `Object::is_equal` simply performs an `==` comparison on the underlying values, which is the same behaviour as the `rb_obj_equal` C function.
