### PR TITLE
[WIP] static linking

### DIFF
--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -31,8 +31,27 @@ pub fn init() {
     }
 }
 
+fn force_loading() {
+    let utf8 = util::str_to_cstring("UTF-8");
+    let ascii_8bit = util::str_to_cstring("ASCII-8BIT");
+    let binary = util::str_to_cstring("BINARY");
+    let dummy = util::str_to_cstring("DUMMY");
+    let single_byte = util::str_to_cstring("single_byte");
+    unsafe {
+        vm::rb_encdb_declare(ascii_8bit.as_ptr());
+        vm::rb_encdb_alias(binary.as_ptr(), ascii_8bit.as_ptr());
+        vm::rb_encdb_replicate(ascii_8bit.as_ptr(), ascii_8bit.as_ptr());
+        vm::rb_enc_set_base(ascii_8bit.as_ptr(), ascii_8bit.as_ptr());
+        let i = vm::rb_encdb_dummy(dummy.as_ptr());
+        vm::rb_enc_set_dummy(i);
+        vm::rb_encdb_set_unicode(1); // see encindex.h RUBY_ENCINDEX_UTF_8
+        vm::rb_declare_transcoder(utf8.as_ptr(), ascii_8bit.as_ptr(), single_byte.as_ptr());
+    }
+}
+
 pub fn init_loadpath() {
     unsafe {
+        force_loading();
         vm::ruby_init_loadpath();
     }
 }

--- a/src/rubysys/vm.rs
+++ b/src/rubysys/vm.rs
@@ -4,6 +4,14 @@ extern "C" {
     // void
     // ruby_init(void)
     pub fn ruby_init();
+    pub fn rb_encdb_declare(name: *const c_char);
+    pub fn rb_encdb_alias(alias: *const c_char, orig: *const c_char);
+    pub fn rb_encdb_replicate(name: *const c_char, orig: *const c_char) -> c_int;
+    pub fn rb_enc_set_base(name: *const c_char, orig: *const c_char);
+    pub fn rb_encdb_dummy(name: *const c_char) -> c_int;
+    pub fn rb_enc_set_dummy(index: c_int) -> c_int;
+    pub fn rb_encdb_set_unicode(index: c_int);
+    pub fn rb_declare_transcoder(enc1: *const c_char, enc2: *const c_char, lib: *const c_char);
     // void
     // ruby_init_loadpath(void)
     pub fn ruby_init_loadpath();


### PR DESCRIPTION
this is an exploration that makes the problem `class::vm::VM::init_loadpath` test from #45 pass.

It does this by explicitly calling the methods that are being reported as "lazy symbol binding failed" until there are no such errors remaining.

There are two potential problems with this.
 
1. I'm trying to do the minimum to make these work, but they lead to warnings such as
   ```
   stderr:
   ruby: warning: already initialized constant Encoding::ASCII_8BIT
   /Users/mike/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-darwin18/enc/encdb.bundle: warning: already initialized constant Encoding::ASCII_8BIT
   ```
1. `init_loadpath` passes, but the string tests now fail in a worse way:
   ```
   /Users/mike/.rbenv/versions/2.6.3/lib/ruby/2.6.0/x86_64-darwin18/enc/utf_32be.bundle: [BUG] vm_call_cfunc: cfp consistency error (0x000000010cdabf90, 0x000000010cdabf58)
   ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin18]

   -- Crash Report log information --------------------------------------------
      See Crash Report log file under the one of following:
        * ~/Library/Logs/DiagnosticReports
        * /Library/Logs/DiagnosticReports
      for more details.
   Don't forget to include the above Crash Report log file in bug reports.

   -- Control frame information -----------------------------------------------
   c:0004 p:-17529622890518 s:0014 e:000013 TOP    [FINISH]
   c:0003 p:---- s:0011 e:000010 CFUNC  :force_encoding
   c:0002 p:0007 s:0006 e:000005 EVAL   eval:1 [FINISH]
   c:0001 p:0000 s:0003 E:001360 (none) [FINISH]
   ```

I see that the build is failing on travis: `error: could not find native static library 'ruby.2.6-static', perhaps an -L flag is missing?`.  To build locally, I did the following:
```
RUSTFLAGS="-L /Users/mike/.rbenv/versions/2.6.3/lib" RUBY_STATIC=true BUILD_RUBY_VERSION=2.6.3 cargo test -vv
```