### PR TITLE
Better names for different `itself` - Issue #121

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class!(RutieExample);
 
 methods!(
     RutieExample,
-    _itself,
+    _rtself,
 
     fn pub_reverse(input: RString) -> RString {
         let ruby_string = input.
@@ -140,8 +140,8 @@ methods!(
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_rutie_ruby_example() {
-    Class::new("RutieExample", None).define(|itself| {
-        itself.def_self("reverse", pub_reverse);
+    Class::new("RutieExample", None).define(|klass| {
+        klass.def_self("reverse", pub_reverse);
     });
 }
 ```
@@ -301,8 +301,8 @@ class!(Example);
 
 fn main() {
     VM::init();
-    Class::new("Example", None).define(|itself| {
-        itself.def("example_method", example_method);
+    Class::new("Example", None).define(|klass| {
+        klass.def("example_method", example_method);
     });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ use rutie::util::str_to_cstring;
 use rutie::rubysys::class;
 use std::mem;
 
-pub extern fn example_method(argc: Argc, argv: *const AnyObject, _: AnyObject) -> AnyObject {
+pub extern fn example_method(argc: Argc, argv: *const AnyObject, _rtself: AnyObject) -> AnyObject {
     let args = Value::from(0);
 
     unsafe {

--- a/examples/rutie_ruby_example/src/lib.rs
+++ b/examples/rutie_ruby_example/src/lib.rs
@@ -7,7 +7,7 @@ class!(RutieExample);
 
 methods!(
     RutieExample,
-    _itself,
+    _rtself,
 
     fn pub_reverse(input: RString) -> RString {
         let ruby_string = input.
@@ -27,7 +27,7 @@ methods!(
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_rutie_ruby_example() {
-    Class::new("RutieExample", None).define(|itself| {
-        itself.def_self("reverse", pub_reverse);
+    Class::new("RutieExample", None).define(|klass| {
+        klass.def_self("reverse", pub_reverse);
     });
 }

--- a/examples/rutie_ruby_gvl_example/src/lib.rs
+++ b/examples/rutie_ruby_gvl_example/src/lib.rs
@@ -10,7 +10,7 @@ class!(RutieExample);
 
 methods! {
     RutieExample,
-    _itself,
+    _rtself,
     fn heap_allocated_returning_input() -> RString {
         let input = "Object".to_string();
         let handler = move || {
@@ -99,12 +99,12 @@ fn fibonacci(n: u32) -> u32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_rutie_ruby_gvl_example() {
-    Class::new("RutieExample", None).define(|itself| {
-        itself.def_self("stack_allocated_returning_input", stack_allocated_returning_input);
-        itself.def_self("stack_allocated_returning_from_closure", stack_allocated_returning_from_closure);
-        itself.def_self("heap_allocated_returning_input", heap_allocated_returning_input);
-        itself.def_self("heap_allocated_returning_from_closure", heap_allocated_returning_from_closure);
-        itself.def_self("call_ruby_in_call_with_gvl", call_ruby_in_call_with_gvl);
-        itself.def_self("create_thread", create_thread);
+    Class::new("RutieExample", None).define(|klass| {
+        klass.def_self("stack_allocated_returning_input", stack_allocated_returning_input);
+        klass.def_self("stack_allocated_returning_from_closure", stack_allocated_returning_from_closure);
+        klass.def_self("heap_allocated_returning_input", heap_allocated_returning_input);
+        klass.def_self("heap_allocated_returning_from_closure", heap_allocated_returning_from_closure);
+        klass.def_self("call_ruby_in_call_with_gvl", call_ruby_in_call_with_gvl);
+        klass.def_self("create_thread", create_thread);
     });
 }

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -21,7 +21,7 @@ use {AnyObject, Array, Object, Module, VerifiedObject};
 ///
 /// methods!(
 ///    Fixnum,
-///    itself,
+///    rtself,
 ///
 ///     fn pow(exp: Fixnum) -> Fixnum {
 ///         // `exp` is not a valid `Fixnum`, raise an exception
@@ -32,14 +32,14 @@ use {AnyObject, Array, Object, Module, VerifiedObject};
 ///         // We can safely unwrap here, because an exception was raised if `exp` is `Err`
 ///         let exp = exp.unwrap().to_i64() as u32;
 ///
-///         Fixnum::new(itself.to_i64().pow(exp))
+///         Fixnum::new(rtself.to_i64().pow(exp))
 ///     }
 /// );
 ///
 /// fn main() {
 ///     # VM::init();
-///     Class::from_existing("Fixnum").define(|itself| {
-///         itself.def("pow", pow);
+///     Class::from_existing("Fixnum").define(|klass| {
+///         klass.def("pow", pow);
 ///     });
 /// }
 /// ```
@@ -270,8 +270,8 @@ impl Class {
     /// use rutie::{Class, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Outer", None).define(|itself| {
-    ///     itself.define_nested_class("Inner", None);
+    /// Class::new("Outer", None).define(|klass| {
+    ///     klass.define_nested_class("Inner", None);
     /// });
     ///
     /// Class::from_existing("Outer").get_nested_class("Inner");
@@ -303,8 +303,8 @@ impl Class {
     /// use rutie::{Class, Module, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Outer", None).define(|itself| {
-    ///     itself.define_nested_module("Inner");
+    /// Class::new("Outer", None).define(|klass| {
+    ///     klass.define_nested_module("Inner");
     /// });
     ///
     /// Class::from_existing("Outer").get_nested_module("Inner");
@@ -342,8 +342,8 @@ impl Class {
     /// use rutie::{Class, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Outer", None).define(|itself| {
-    ///     itself.define_nested_class("Inner", None);
+    /// Class::new("Outer", None).define(|klass| {
+    ///     klass.define_nested_class("Inner", None);
     /// });
     ///
     /// Class::from_existing("Outer").get_nested_class("Inner");
@@ -377,8 +377,8 @@ impl Class {
     /// use rutie::{Class, Module, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Outer", None).define(|itself| {
-    ///     itself.define_nested_module("Inner");
+    /// Class::new("Outer", None).define(|klass| {
+    ///     klass.define_nested_module("Inner");
     /// });
     ///
     /// Module::from_existing("Outer").get_nested_module("Inner");
@@ -410,8 +410,8 @@ impl Class {
     /// use rutie::{Class, Object, RString, VM};
     /// # VM::init();
     ///
-    /// Class::new("Greeter", None).define(|itself| {
-    ///     itself.const_set("GREETING", &RString::new_utf8("Hello, World!"));
+    /// Class::new("Greeter", None).define(|klass| {
+    ///     klass.const_set("GREETING", &RString::new_utf8("Hello, World!"));
     /// });
     ///
     /// let greeting = Class::from_existing("Greeter")
@@ -456,8 +456,8 @@ impl Class {
     /// use rutie::{Class, Object, RString, VM};
     /// # VM::init();
     ///
-    /// Class::new("Greeter", None).define(|itself| {
-    ///     itself.const_set("GREETING", &RString::new_utf8("Hello, World!"));
+    /// Class::new("Greeter", None).define(|klass| {
+    ///     klass.const_set("GREETING", &RString::new_utf8("Hello, World!"));
     /// });
     ///
     /// let greeting = Class::from_existing("Greeter")
@@ -540,8 +540,8 @@ impl Class {
     /// use rutie::{Class, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Test", None).define(|itself| {
-    ///     itself.attr_reader("reader");
+    /// Class::new("Test", None).define(|klass| {
+    ///     klass.attr_reader("reader");
     /// });
     /// ```
     ///
@@ -564,8 +564,8 @@ impl Class {
     /// use rutie::{Class, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Test", None).define(|itself| {
-    ///     itself.attr_writer("writer");
+    /// Class::new("Test", None).define(|klass| {
+    ///     klass.attr_writer("writer");
     /// });
     /// ```
     ///
@@ -588,8 +588,8 @@ impl Class {
     /// use rutie::{Class, Object, VM};
     /// # VM::init();
     ///
-    /// Class::new("Test", None).define(|itself| {
-    ///     itself.attr_accessor("accessor");
+    /// Class::new("Test", None).define(|klass| {
+    ///     klass.attr_accessor("accessor");
     /// });
     /// ```
     ///
@@ -647,7 +647,7 @@ impl Class {
     ///
     /// methods!(
     ///     RubyServer,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn ruby_server_new(host: RString, port: Fixnum) -> AnyObject {
     ///         let server = Server::new(host.unwrap().to_string(),
@@ -657,13 +657,13 @@ impl Class {
     ///     }
     ///
     ///     fn ruby_server_host() -> RString {
-    ///         let host = itself.get_data(&*SERVER_WRAPPER).host();
+    ///         let host = rtself.get_data(&*SERVER_WRAPPER).host();
     ///
     ///         RString::new_utf8(host)
     ///     }
     ///
     ///     fn ruby_server_port() -> Fixnum {
-    ///         let port = itself.get_data(&*SERVER_WRAPPER).port();
+    ///         let port = rtself.get_data(&*SERVER_WRAPPER).port();
     ///
     ///         Fixnum::new(port as i64)
     ///     }
@@ -673,11 +673,11 @@ impl Class {
     ///     # VM::init();
     ///     let data_class = Class::from_existing("Object");
     ///
-    ///     Class::new("RubyServer", Some(&data_class)).define(|itself| {
-    ///         itself.def_self("new", ruby_server_new);
+    ///     Class::new("RubyServer", Some(&data_class)).define(|klass| {
+    ///         klass.def_self("new", ruby_server_new);
     ///
-    ///         itself.def("host", ruby_server_host);
-    ///         itself.def("port", ruby_server_port);
+    ///         klass.def("host", ruby_server_host);
+    ///         klass.def("port", ruby_server_port);
     ///     });
     /// }
     /// ```

--- a/src/class/module.rs
+++ b/src/class/module.rs
@@ -22,7 +22,7 @@ use {AnyObject, Array, Object, Class, VerifiedObject};
 ///
 /// methods!(
 ///    Example,
-///    itself,
+///    rtself,
 ///
 ///     fn square(exp: Fixnum) -> Fixnum {
 ///         // `exp` is not a valid `Fixnum`, raise an exception
@@ -39,8 +39,8 @@ use {AnyObject, Array, Object, Class, VerifiedObject};
 ///
 /// fn main() {
 ///     # VM::init();
-///     Module::new("Example").define(|itself| {
-///         itself.def("square", square);
+///     Module::new("Example").define(|klass| {
+///         klass.def("square", square);
 ///     });
 /// }
 /// ```
@@ -167,8 +167,8 @@ impl Module {
     /// use rutie::{Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Outer").define(|itself| {
-    ///     itself.define_nested_module("Inner");
+    /// Module::new("Outer").define(|klass| {
+    ///     klass.define_nested_module("Inner");
     /// });
     ///
     /// Module::from_existing("Outer").get_nested_module("Inner");
@@ -200,8 +200,8 @@ impl Module {
     /// use rutie::{Class, Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Outer").define(|itself| {
-    ///     itself.define_nested_class("Inner", None);
+    /// Module::new("Outer").define(|klass| {
+    ///     klass.define_nested_class("Inner", None);
     /// });
     ///
     /// Module::from_existing("Outer").get_nested_class("Inner");
@@ -233,8 +233,8 @@ impl Module {
     /// use rutie::{Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Outer").define(|itself| {
-    ///     itself.define_nested_module("Inner");
+    /// Module::new("Outer").define(|klass| {
+    ///     klass.define_nested_module("Inner");
     /// });
     ///
     /// Module::from_existing("Outer").get_nested_module("Inner");
@@ -266,8 +266,8 @@ impl Module {
     /// use rutie::{Class, Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Outer").define(|itself| {
-    ///     itself.define_nested_class("Inner", None);
+    /// Module::new("Outer").define(|klass| {
+    ///     klass.define_nested_class("Inner", None);
     /// });
     ///
     /// Module::from_existing("Outer").get_nested_class("Inner");
@@ -318,17 +318,17 @@ impl Module {
     ///
     /// methods!(
     ///    RString,
-    ///    itself,
+    ///    rtself,
     ///
     ///    fn is_blank() -> Boolean {
-    ///        Boolean::new(itself.to_str().chars().all(|c| c.is_whitespace()))
+    ///        Boolean::new(rtself.to_str().chars().all(|c| c.is_whitespace()))
     ///    }
     /// );
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Module::new("Blank").define(|itself| {
-    ///         itself.mod_func("blank?", is_blank);
+    ///     Module::new("Blank").define(|klass| {
+    ///         klass.mod_func("blank?", is_blank);
     ///     });
     ///
     ///     Class::from_existing("String").include("Blank");
@@ -362,7 +362,7 @@ impl Module {
     ///
     /// methods!(
     ///     Fixnum,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn pow(exp: Fixnum) -> Fixnum {
     ///         // `exp` is not a valid `Fixnum`, raise an exception
@@ -373,14 +373,14 @@ impl Module {
     ///         // We can safely unwrap here, because an exception was raised if `exp` is `Err`
     ///         let exp = exp.unwrap().to_i64() as u32;
     ///
-    ///         Fixnum::new(itself.to_i64().pow(exp))
+    ///         Fixnum::new(rtself.to_i64().pow(exp))
     ///     }
     ///
     ///     fn pow_with_default_argument(exp: Fixnum) -> Fixnum {
     ///         let default_exp = 0;
     ///         let exp = exp.map(|exp| exp.to_i64()).unwrap_or(default_exp);
     ///
-    ///         let result = itself.to_i64().pow(exp as u32);
+    ///         let result = rtself.to_i64().pow(exp as u32);
     ///
     ///         Fixnum::new(result)
     ///     }
@@ -388,9 +388,9 @@ impl Module {
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Module::from_existing("Fixnum").define(|itself| {
-    ///         itself.mod_func("pow", pow);
-    ///         itself.mod_func("pow_with_default_argument", pow_with_default_argument);
+    ///     Module::from_existing("Fixnum").define(|klass| {
+    ///         klass.mod_func("pow", pow);
+    ///         klass.mod_func("pow_with_default_argument", pow_with_default_argument);
     ///     });
     /// }
     /// ```
@@ -432,8 +432,8 @@ impl Module {
     /// use rutie::{Module, Object, RString, VM};
     /// # VM::init();
     ///
-    /// Module::new("Greeter").define(|itself| {
-    ///     itself.const_set("GREETING", &RString::new_utf8("Hello, World!"));
+    /// Module::new("Greeter").define(|klass| {
+    ///     klass.const_set("GREETING", &RString::new_utf8("Hello, World!"));
     /// });
     ///
     /// let greeting = Module::from_existing("Greeter")
@@ -478,8 +478,8 @@ impl Module {
     /// use rutie::{Module, Object, RString, VM};
     /// # VM::init();
     ///
-    /// Module::new("Greeter").define(|itself| {
-    ///     itself.const_set("GREETING", &RString::new_utf8("Hello, World!"));
+    /// Module::new("Greeter").define(|klass| {
+    ///     klass.const_set("GREETING", &RString::new_utf8("Hello, World!"));
     /// });
     ///
     /// let greeting = Module::from_existing("Greeter")
@@ -570,8 +570,8 @@ impl Module {
     /// use rutie::{Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Test").define(|itself| {
-    ///     itself.attr_reader("reader");
+    /// Module::new("Test").define(|klass| {
+    ///     klass.attr_reader("reader");
     /// });
     /// ```
     ///
@@ -594,8 +594,8 @@ impl Module {
     /// use rutie::{Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Test").define(|itself| {
-    ///     itself.attr_writer("writer");
+    /// Module::new("Test").define(|klass| {
+    ///     klass.attr_writer("writer");
     /// });
     /// ```
     ///
@@ -618,8 +618,8 @@ impl Module {
     /// use rutie::{Module, Object, VM};
     /// # VM::init();
     ///
-    /// Module::new("Test").define(|itself| {
-    ///     itself.attr_accessor("accessor");
+    /// Module::new("Test").define(|klass| {
+    ///     klass.attr_accessor("accessor");
     /// });
     /// ```
     ///
@@ -678,7 +678,7 @@ impl Module {
     ///
     /// methods!(
     ///     RubyServer,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn ruby_server_new(host: RString, port: Fixnum) -> AnyObject {
     ///         let server = Server::new(host.unwrap().to_string(),
@@ -688,13 +688,13 @@ impl Module {
     ///     }
     ///
     ///     fn ruby_server_host() -> RString {
-    ///         let host = itself.get_data(&*SERVER_WRAPPER).host();
+    ///         let host = rtself.get_data(&*SERVER_WRAPPER).host();
     ///
     ///         RString::new_utf8(host)
     ///     }
     ///
     ///     fn ruby_server_port() -> Fixnum {
-    ///         let port = itself.get_data(&*SERVER_WRAPPER).port();
+    ///         let port = rtself.get_data(&*SERVER_WRAPPER).port();
     ///
     ///         Fixnum::new(port as i64)
     ///     }
@@ -704,11 +704,11 @@ impl Module {
     ///     # VM::init();
     ///     let data_class = Class::from_existing("Object");
     ///
-    ///     Class::new("RubyServer", None).define(|itself| {
-    ///         itself.def_self("new", ruby_server_new);
+    ///     Class::new("RubyServer", None).define(|klass| {
+    ///         klass.def_self("new", ruby_server_new);
     ///
-    ///         itself.def("host", ruby_server_host);
-    ///         itself.def("port", ruby_server_port);
+    ///         klass.def("host", ruby_server_host);
+    ///         klass.def("port", ruby_server_port);
     ///     });
     /// }
     /// ```

--- a/src/class/rproc.rs
+++ b/src/class/rproc.rs
@@ -27,7 +27,7 @@ impl Proc {
     ///
     /// methods!(
     ///     Greeter,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn greet_rust_with(greeting_template: Proc) -> RString {
     ///         let name = RString::new_utf8("Rust").to_any_object();
@@ -38,8 +38,8 @@ impl Proc {
     /// );
     ///
     /// fn main() {
-    ///     Class::new("Greeter", None).define(|itself| {
-    ///         itself.def_self("greet_rust_with", greet_rust_with);
+    ///     Class::new("Greeter", None).define(|klass| {
+    ///         klass.def_self("greet_rust_with", greet_rust_with);
     ///     });
     /// }
     /// ```

--- a/src/class/thread.rs
+++ b/src/class/thread.rs
@@ -92,7 +92,7 @@ impl Thread {
     ///
     /// methods!(
     ///     Calculator,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn heavy_computation() -> Fixnum {
     ///         let computation = || { 2 * 2 };
@@ -110,8 +110,8 @@ impl Thread {
     /// );
     ///
     /// fn main() {
-    ///     Class::new("Calculator", None).define(|itself| {
-    ///         itself.def("heavy_computation", heavy_computation);
+    ///     Class::new("Calculator", None).define(|klass| {
+    ///         klass.def("heavy_computation", heavy_computation);
     ///     });
     /// }
     /// ```

--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -93,8 +93,8 @@ pub trait Object: From<Value> {
     /// let array = Array::new();
     /// let another_array = Array::new();
     ///
-    /// array.singleton_class().define(|itself| {
-    ///     itself.attr_reader("modified");
+    /// array.singleton_class().define(|klass| {
+    ///     klass.attr_reader("modified");
     /// });
     ///
     /// assert!(array.respond_to("modified"));
@@ -161,7 +161,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     RubyServer,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn ruby_server_new(host: RString, port: Fixnum) -> AnyObject {
     ///         let server = Server::new(host.unwrap().to_string(),
@@ -171,13 +171,13 @@ pub trait Object: From<Value> {
     ///     }
     ///
     ///     fn ruby_server_host() -> RString {
-    ///         let host = itself.get_data(&*SERVER_WRAPPER).host();
+    ///         let host = rtself.get_data(&*SERVER_WRAPPER).host();
     ///
     ///         RString::new_utf8(host)
     ///     }
     ///
     ///     fn ruby_server_port() -> Fixnum {
-    ///         let port = itself.get_data(&*SERVER_WRAPPER).port();
+    ///         let port = rtself.get_data(&*SERVER_WRAPPER).port();
     ///
     ///         Fixnum::new(port as i64)
     ///     }
@@ -187,11 +187,11 @@ pub trait Object: From<Value> {
     ///     # VM::init();
     ///     let data_class = Class::from_existing("Object");
     ///
-    ///     Class::new("RubyServer", Some(&data_class)).define(|itself| {
-    ///         itself.def_self("new", ruby_server_new);
+    ///     Class::new("RubyServer", Some(&data_class)).define(|klass| {
+    ///         klass.def_self("new", ruby_server_new);
     ///
-    ///         itself.def("host", ruby_server_host);
-    ///         itself.def("port", ruby_server_port);
+    ///         klass.def("host", ruby_server_host);
+    ///         klass.def("port", ruby_server_port);
     ///     });
     /// }
     /// ```
@@ -231,7 +231,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Hello,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn greeting() -> RString {
     ///         RString::new_utf8("Greeting from class")
@@ -244,7 +244,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Nested,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn nested_greeting() -> RString {
     ///         RString::new_utf8("Greeting from nested class")
@@ -252,14 +252,14 @@ pub trait Object: From<Value> {
     /// );
     ///
     /// fn main() {
-    ///     Class::new("Hello", None).define(|itself| {
-    ///         itself.attr_reader("reader");
+    ///     Class::new("Hello", None).define(|klass| {
+    ///         klass.attr_reader("reader");
     ///
-    ///         itself.def_self("greeting", greeting);
-    ///         itself.def("many_greetings", many_greetings);
+    ///         klass.def_self("greeting", greeting);
+    ///         klass.def("many_greetings", many_greetings);
     ///
-    ///         itself.define_nested_class("Nested", None).define(|itself| {
-    ///             itself.def_self("nested_greeting", nested_greeting);
+    ///         klass.define_nested_class("Nested", None).define(|klass| {
+    ///             klass.def_self("nested_greeting", nested_greeting);
     ///         });
     ///     });
     /// }
@@ -296,7 +296,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     RString,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn greeting() -> RString {
     ///         RString::new_utf8("Greeting!")
@@ -309,8 +309,8 @@ pub trait Object: From<Value> {
     ///
     ///     // The same can be done by modifying `string.singleton_class()`
     ///     // or using `string.define_singleton_method("greeting", greeting)`
-    ///     string.define(|itself| {
-    ///         itself.define_singleton_method("greeting", greeting);
+    ///     string.define(|klass| {
+    ///         klass.define_singleton_method("greeting", greeting);
     ///     });
     ///
     ///     assert!(string.respond_to("greeting"));
@@ -361,17 +361,17 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///    RString,
-    ///    itself,
+    ///    rtself,
     ///
     ///    fn is_blank() -> Boolean {
-    ///        Boolean::new(itself.to_str().chars().all(|c| c.is_whitespace()))
+    ///        Boolean::new(rtself.to_str().chars().all(|c| c.is_whitespace()))
     ///    }
     /// );
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::from_existing("String").define(|itself| {
-    ///         itself.def("blank?", is_blank);
+    ///     Class::from_existing("String").define(|klass| {
+    ///         klass.def("blank?", is_blank);
     ///     });
     /// }
     /// ```
@@ -400,7 +400,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Fixnum,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn pow(exp: Fixnum) -> Fixnum {
     ///         // `exp` is not a valid `Fixnum`, raise an exception
@@ -411,14 +411,14 @@ pub trait Object: From<Value> {
     ///         // We can safely unwrap here, because an exception was raised if `exp` is `Err`
     ///         let exp = exp.unwrap().to_i64() as u32;
     ///
-    ///         Fixnum::new(itself.to_i64().pow(exp))
+    ///         Fixnum::new(rtself.to_i64().pow(exp))
     ///     }
     ///
     ///     fn pow_with_default_argument(exp: Fixnum) -> Fixnum {
     ///         let default_exp = 0;
     ///         let exp = exp.map(|exp| exp.to_i64()).unwrap_or(default_exp);
     ///
-    ///         let result = itself.to_i64().pow(exp as u32);
+    ///         let result = rtself.to_i64().pow(exp as u32);
     ///
     ///         Fixnum::new(result)
     ///     }
@@ -426,9 +426,9 @@ pub trait Object: From<Value> {
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::from_existing("Fixnum").define(|itself| {
-    ///         itself.def("pow", pow);
-    ///         itself.def("pow_with_default_argument", pow_with_default_argument);
+    ///     Class::from_existing("Fixnum").define(|klass| {
+    ///         klass.def("pow", pow);
+    ///         klass.def("pow_with_default_argument", pow_with_default_argument);
     ///     });
     /// }
     /// ```
@@ -480,17 +480,17 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///    RString,
-    ///    itself,
+    ///    rtself,
     ///
     ///    fn is_blank() -> Boolean {
-    ///        Boolean::new(itself.to_str().chars().all(|c| c.is_whitespace()))
+    ///        Boolean::new(rtself.to_str().chars().all(|c| c.is_whitespace()))
     ///    }
     /// );
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::from_existing("String").define(|itself| {
-    ///         itself.def_private("blank?", is_blank);
+    ///     Class::from_existing("String").define(|klass| {
+    ///         klass.def_private("blank?", is_blank);
     ///     });
     /// }
     /// ```
@@ -519,7 +519,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Fixnum,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn pow(exp: Fixnum) -> Fixnum {
     ///         // `exp` is not a valid `Fixnum`, raise an exception
@@ -530,14 +530,14 @@ pub trait Object: From<Value> {
     ///         // We can safely unwrap here, because an exception was raised if `exp` is `Err`
     ///         let exp = exp.unwrap().to_i64() as u32;
     ///
-    ///         Fixnum::new(itself.to_i64().pow(exp))
+    ///         Fixnum::new(rtself.to_i64().pow(exp))
     ///     }
     ///
     ///     fn pow_with_default_argument(exp: Fixnum) -> Fixnum {
     ///         let default_exp = 0;
     ///         let exp = exp.map(|exp| exp.to_i64()).unwrap_or(default_exp);
     ///
-    ///         let result = itself.to_i64().pow(exp as u32);
+    ///         let result = rtself.to_i64().pow(exp as u32);
     ///
     ///         Fixnum::new(result)
     ///     }
@@ -545,9 +545,9 @@ pub trait Object: From<Value> {
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::from_existing("Fixnum").define(|itself| {
-    ///         itself.def_private("pow", pow);
-    ///         itself.def_private("pow_with_default_argument", pow_with_default_argument);
+    ///     Class::from_existing("Fixnum").define(|klass| {
+    ///         klass.def_private("pow", pow);
+    ///         klass.def_private("pow_with_default_argument", pow_with_default_argument);
     ///     });
     /// }
     /// ```
@@ -595,7 +595,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Symbol,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn from_string(string: RString) -> Symbol {
     ///         // `string` is not a valid `String`, raise an exception
@@ -609,8 +609,8 @@ pub trait Object: From<Value> {
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::from_existing("Symbol").define(|itself| {
-    ///         itself.def_self("from_string", from_string);
+    ///     Class::from_existing("Symbol").define(|klass| {
+    ///         klass.def_self("from_string", from_string);
     ///     });
     /// }
     /// ```
@@ -637,7 +637,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     RString,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn greeting() -> RString {
     ///         RString::new_utf8("Greeting!")
@@ -650,8 +650,8 @@ pub trait Object: From<Value> {
     ///
     ///     // The same can be done by modifying `string.singleton_class()`
     ///     // or using `string.define_singleton_method("greeting", greeting)`
-    ///     string.define(|itself| {
-    ///         itself.define_singleton_method("greeting", greeting);
+    ///     string.define(|klass| {
+    ///         klass.define_singleton_method("greeting", greeting);
     ///     });
     ///
     ///     assert!(string.respond_to("greeting"));
@@ -1028,33 +1028,33 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Counter,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn counter_initialize() -> AnyObject {
-    ///         itself.instance_variable_set("@state", Fixnum::new(0))
+    ///         rtself.instance_variable_set("@state", Fixnum::new(0))
     ///     }
     ///
     ///     fn counter_increment() -> AnyObject {
     ///         // Using unsafe conversion, because we are sure that `@state` is always a `Fixnum`
     ///         // and we don't provide an interface to set the value externally
     ///         let state = unsafe {
-    ///             itself.instance_variable_get("@state").to::<Fixnum>().to_i64()
+    ///             rtself.instance_variable_get("@state").to::<Fixnum>().to_i64()
     ///         };
     ///
-    ///         itself.instance_variable_set("@state", Fixnum::new(state + 1))
+    ///         rtself.instance_variable_set("@state", Fixnum::new(state + 1))
     ///     }
     ///
     ///     fn counter_state() -> Fixnum {
-    ///         unsafe { itself.instance_variable_get("@state").to::<Fixnum>() }
+    ///         unsafe { rtself.instance_variable_get("@state").to::<Fixnum>() }
     ///     }
     /// );
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     let counter = Class::new("Counter", None).define(|itself| {
-    ///         itself.def("initialize", counter_initialize);
-    ///         itself.def("increment!", counter_increment);
-    ///         itself.def("state", counter_state);
+    ///     let counter = Class::new("Counter", None).define(|klass| {
+    ///         klass.def("initialize", counter_initialize);
+    ///         klass.def("increment!", counter_increment);
+    ///         klass.def("state", counter_state);
     ///     }).new_instance(&[]);
     ///
     ///     unsafe { counter.send("increment!", &[]) };
@@ -1109,33 +1109,33 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Counter,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn counter_initialize() -> AnyObject {
-    ///         itself.instance_variable_set("@state", Fixnum::new(0))
+    ///         rtself.instance_variable_set("@state", Fixnum::new(0))
     ///     }
     ///
     ///     fn counter_increment() -> AnyObject {
     ///         // Using unsafe conversion, because we are sure that `@state` is always a `Fixnum`
     ///         // and we don't provide an interface to set the value externally
     ///         let state = unsafe {
-    ///             itself.instance_variable_get("@state").to::<Fixnum>().to_i64()
+    ///             rtself.instance_variable_get("@state").to::<Fixnum>().to_i64()
     ///         };
     ///
-    ///         itself.instance_variable_set("@state", Fixnum::new(state + 1))
+    ///         rtself.instance_variable_set("@state", Fixnum::new(state + 1))
     ///     }
     ///
     ///     fn counter_state() -> Fixnum {
-    ///         unsafe { itself.instance_variable_get("@state").to::<Fixnum>() }
+    ///         unsafe { rtself.instance_variable_get("@state").to::<Fixnum>() }
     ///     }
     /// );
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     let counter = Class::new("Counter", None).define(|itself| {
-    ///         itself.def("initialize", counter_initialize);
-    ///         itself.def("increment!", counter_increment);
-    ///         itself.def("state", counter_state);
+    ///     let counter = Class::new("Counter", None).define(|klass| {
+    ///         klass.def("initialize", counter_initialize);
+    ///         klass.def("increment!", counter_increment);
+    ///         klass.def("state", counter_state);
     ///     }).new_instance(&[]);
     ///
     ///     unsafe { counter.send("increment!", &[]) };
@@ -1327,7 +1327,7 @@ pub trait Object: From<Value> {
     ///
     /// methods!(
     ///     Server,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn start(address: Hash) -> NilClass {
     ///         let default_port = 8080;
@@ -1346,8 +1346,8 @@ pub trait Object: From<Value> {
     ///
     /// fn main() {
     ///     # VM::init();
-    ///     Class::new("Server", None).define(|itself| {
-    ///         itself.def("start", start);
+    ///     Class::new("Server", None).define(|klass| {
+    ///         klass.def("start", start);
     ///     });
     /// }
     /// ```

--- a/src/class/traits/verified_object.rs
+++ b/src/class/traits/verified_object.rs
@@ -48,7 +48,7 @@ use Object;
 ///
 /// methods!(
 ///     Request,
-///     itself,
+///     rtself,
 ///
 ///     fn protocol() -> RString { RString::new_utf8("HTTP") }
 ///     fn body() -> RString { RString::new_utf8("request body") }
@@ -96,9 +96,9 @@ use Object;
 ///     Class::new("Server", None);
 ///     Class::new("Response", Some(&Class::new("BasicResponse", None)));
 ///     Class::new("Headers", Some(&Class::from_existing("Hash")));
-///     Class::new("Request", None).define(|itself| {
-///         itself.def("protocol", protocol);
-///         itself.def("body", body);
+///     Class::new("Request", None).define(|klass| {
+///         klass.def("protocol", protocol);
+///         klass.def("body", body);
 ///     });
 ///
 ///     // Create new instances of classes and convert them to `AnyObject`s

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -292,7 +292,7 @@ impl VM {
     ///
     /// methods!(
     ///     Greeter,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn greet_rust_with() -> RString {
     ///         let greeting_template = VM::block_proc();
@@ -303,8 +303,8 @@ impl VM {
     /// );
     ///
     /// fn main() {
-    ///     Class::new("Greeter", None).define(|itself| {
-    ///         itself.def_self("greet_rust_with", greet_rust_with);
+    ///     Class::new("Greeter", None).define(|klass| {
+    ///         klass.def_self("greet_rust_with", greet_rust_with);
     ///     });
     /// }
     /// ```
@@ -340,7 +340,7 @@ impl VM {
     ///
     /// methods!(
     ///     Calculator,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn calculate(a: Fixnum, b: Fixnum) -> Fixnum {
     ///         let a = a.unwrap();
@@ -360,8 +360,8 @@ impl VM {
     /// fn main() {
     ///     # VM::init();
     ///
-    ///     Class::new("Calculator", None).define(|itself| {
-    ///         itself.def("calculate", calculate);
+    ///     Class::new("Calculator", None).define(|klass| {
+    ///         klass.def("calculate", calculate);
     ///     });
     /// }
     /// ```
@@ -396,7 +396,7 @@ impl VM {
     ///
     /// methods!(
     ///     Calculator,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn calculate(a: Fixnum) -> Fixnum {
     ///         let a = a.map_err(|e| VM::raise_ex(e) ).unwrap();
@@ -416,8 +416,8 @@ impl VM {
     /// fn main() {
     ///     # VM::init();
     ///
-    ///     Class::new("Calculator", None).define(|itself| {
-    ///         itself.def("calculate", calculate);
+    ///     Class::new("Calculator", None).define(|klass| {
+    ///         klass.def("calculate", calculate);
     ///     });
     ///
     ///     let result = VM::eval(" Calculator.new().calculate(4) { |n| n * n } ").unwrap();
@@ -459,7 +459,7 @@ impl VM {
     ///
     /// methods!(
     ///     Calculator,
-    ///     itself,
+    ///     rtself,
     ///
     ///     fn calculate(a: Array) -> Fixnum {
     ///         let a = a.map_err(|e| VM::raise_ex(e) ).unwrap();
@@ -479,8 +479,8 @@ impl VM {
     /// fn main() {
     ///     # VM::init();
     ///
-    ///     Class::new("Calculator", None).define(|itself| {
-    ///         itself.def("calculate", calculate);
+    ///     Class::new("Calculator", None).define(|klass| {
+    ///         klass.def("calculate", calculate);
     ///     });
     ///
     ///     let result = VM::eval(" Calculator.new().calculate([4,6,8]) { |a,b,c| a*b-c } ").unwrap();

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -15,7 +15,7 @@
 ///
 /// methods!(
 ///     Greeter,
-///     itself,
+///     rtself,
 ///
 ///     fn anonymous_greeting() -> RString {
 ///         RString::new_utf8("Hello stranger!")
@@ -34,9 +34,9 @@
 ///
 /// fn main() {
 ///     # VM::init();
-///     Class::new("Greeter", None).define(|itself| {
-///         itself.def("anonymous_greeting", anonymous_greeting);
-///         itself.def("friendly_greeting", friendly_greeting);
+///     Class::new("Greeter", None).define(|klass| {
+///         klass.def("anonymous_greeting", anonymous_greeting);
+///         klass.def("friendly_greeting", friendly_greeting);
 ///     });
 /// }
 /// ```
@@ -98,7 +98,7 @@ macro_rules! class {
 ///
 /// methods!(
 ///     Greeter,
-///     itself,
+///     rtself,
 ///
 ///     fn anonymous_greeting() -> RString {
 ///         RString::new_utf8("Hello stranger!")
@@ -117,9 +117,9 @@ macro_rules! class {
 ///
 /// fn main() {
 ///     # VM::init();
-///     Module::new("Greeter").define(|itself| {
-///         itself.def("anonymous_greeting", anonymous_greeting);
-///         itself.def("friendly_greeting", friendly_greeting);
+///     Module::new("Greeter").define(|klass| {
+///         klass.def("anonymous_greeting", anonymous_greeting);
+///         klass.def("friendly_greeting", friendly_greeting);
 ///     });
 /// }
 /// ```
@@ -195,10 +195,10 @@ macro_rules! module {
 /// // Creates `string_length_equals` functions
 /// unsafe_methods!(
 ///     RString, // type of `self` object
-///     itself, // name of `self` object which will be used in methods
+///     rtself, // name of `self` object which will be used in methods
 ///
 ///     fn string_length_equals(expected_length: Fixnum) -> Boolean {
-///         let real_length = itself.to_str().len() as i64;
+///         let real_length = rtself.to_str().len() as i64;
 ///
 ///         Boolean::new(expected_length.to_i64() == real_length)
 ///     }
@@ -206,8 +206,8 @@ macro_rules! module {
 ///
 /// fn main() {
 ///     # VM::init();
-///     Class::from_existing("String").define(|itself| {
-///         itself.def("length_equals?", string_length_equals);
+///     Class::from_existing("String").define(|klass| {
+///         klass.def("length_equals?", string_length_equals);
 ///     });
 /// }
 /// ```
@@ -228,8 +228,8 @@ macro_rules! module {
 #[macro_export]
 macro_rules! unsafe_methods {
     (
-        $itself_class: ty,
-        $itself_name: ident,
+        $rtself_class: ty,
+        $rtself_name: ident,
         $(
             fn $method_name: ident
             ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ty $body: block
@@ -239,7 +239,7 @@ macro_rules! unsafe_methods {
             #[allow(unused_mut)]
             pub extern fn $method_name(argc: $crate::types::Argc,
                                        argv: *const $crate::AnyObject,
-                                       mut $itself_name: $itself_class) -> $return_type {
+                                       mut $rtself_name: $rtself_class) -> $return_type {
                 let _arguments = $crate::util::parse_arguments(argc, argv);
                 let mut _i = 0;
 
@@ -309,7 +309,7 @@ macro_rules! unsafe_methods {
 ///
 /// methods!(
 ///     Server,
-///     itself,
+///     rtself,
 ///
 ///     fn start(address: Hash) -> NilClass {
 ///         let default_port = 8080;
@@ -328,8 +328,8 @@ macro_rules! unsafe_methods {
 ///
 /// fn main() {
 ///     # VM::init();
-///     Class::new("Server", None).define(|itself| {
-///         itself.def("start", start);
+///     Class::new("Server", None).define(|klass| {
+///         klass.def("start", start);
 ///     });
 /// }
 /// ```
@@ -355,8 +355,8 @@ macro_rules! unsafe_methods {
 #[macro_export]
 macro_rules! methods {
     (
-        $itself_class: ty,
-        $itself_name: ident,
+        $rtself_class: ty,
+        $rtself_name: ident,
         $(
             fn $method_name: ident
             ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ident $body: block
@@ -366,7 +366,7 @@ macro_rules! methods {
             #[allow(unused_mut)]
             pub extern fn $method_name(argc: $crate::types::Argc,
                                        argv: *const $crate::AnyObject,
-                                       mut $itself_name: $itself_class) -> $return_type {
+                                       mut $rtself_name: $rtself_class) -> $return_type {
                 let _arguments = $crate::util::parse_arguments(argc, argv);
                 let mut _i = 0;
 
@@ -522,7 +522,7 @@ macro_rules! methods {
 ///
 /// methods!(
 ///     RubyServer,
-///     itself,
+///     rtself,
 ///
 ///     fn ruby_server_new(host: RString, port: Fixnum) -> AnyObject {
 ///         let server = Server::new(host.unwrap().to_string(),
@@ -532,13 +532,13 @@ macro_rules! methods {
 ///     }
 ///
 ///     fn ruby_server_host() -> RString {
-///         let host = itself.get_data(&*SERVER_WRAPPER).host();
+///         let host = rtself.get_data(&*SERVER_WRAPPER).host();
 ///
 ///         RString::new_utf8(host)
 ///     }
 ///
 ///     fn ruby_server_port() -> Fixnum {
-///         let port = itself.get_data(&*SERVER_WRAPPER).port();
+///         let port = rtself.get_data(&*SERVER_WRAPPER).port();
 ///
 ///         Fixnum::new(port as i64)
 ///     }
@@ -548,11 +548,11 @@ macro_rules! methods {
 ///     # VM::init();
 ///     let data_class = Class::from_existing("Object");
 ///
-///     Class::new("RubyServer", Some(&data_class)).define(|itself| {
-///         itself.def_self("new", ruby_server_new);
+///     Class::new("RubyServer", Some(&data_class)).define(|klass| {
+///         klass.def_self("new", ruby_server_new);
 ///
-///         itself.def("host", ruby_server_host);
-///         itself.def("port", ruby_server_port);
+///         klass.def("host", ruby_server_host);
+///         klass.def("port", ruby_server_port);
 ///     });
 /// }
 /// ```
@@ -622,7 +622,7 @@ macro_rules! methods {
 ///
 /// methods! {
 ///     RustyArray,
-///     itself,
+///     rtself,
 ///
 ///     fn new() -> AnyObject {
 ///         let vec = VectorOfObjects::new();
@@ -631,13 +631,13 @@ macro_rules! methods {
 ///     }
 ///
 ///     fn push(object: AnyObject) -> NilClass {
-///         itself.get_data_mut(&*VECTOR_OF_OBJECTS_WRAPPER).push(object.unwrap());
+///         rtself.get_data_mut(&*VECTOR_OF_OBJECTS_WRAPPER).push(object.unwrap());
 ///
 ///         NilClass::new()
 ///     }
 ///
 ///     fn length() -> Fixnum {
-///         let length = itself.get_data(&*VECTOR_OF_OBJECTS_WRAPPER).len() as i64;
+///         let length = rtself.get_data(&*VECTOR_OF_OBJECTS_WRAPPER).len() as i64;
 ///
 ///         Fixnum::new(length)
 ///     }
@@ -647,11 +647,11 @@ macro_rules! methods {
 ///     # VM::init();
 ///     let data_class = Class::from_existing("Object");
 ///
-///     Class::new("RustyArray", Some(&data_class)).define(|itself| {
-///         itself.def_self("new", new);
+///     Class::new("RustyArray", Some(&data_class)).define(|klass| {
+///         klass.def_self("new", new);
 ///
-///         itself.def("push", push);
-///         itself.def("length", length);
+///         klass.def("push", push);
+///         klass.def("length", length);
 ///     });
 /// }
 /// ```

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,11 +73,11 @@ pub fn option_to_slice<'a, T>(option: &'a Option<T>) -> &'a [T] {
 // use rutie::{AnyObject, Boolean, Class, Object, RString, util};
 //
 // #[no_mangle]
-// pub extern fn string_eq(argc: Argc, argv: *const AnyObject, itself: RString) -> Boolean {
+// pub extern fn string_eq(argc: Argc, argv: *const AnyObject, rtself: RString) -> Boolean {
 //     let argv = util::parse_arguments(argc, argv);
 //     let other_string = argv[0].try_convert_to::<RString>().unwrap();
 //
-//     Boolean::new(itself.to_str() == other_string.to_str())
+//     Boolean::new(rtself.to_str() == other_string.to_str())
 // }
 //
 // fn main() {


### PR DESCRIPTION
Solve #121 

Change variables' names for better clarity

In methods! macro
itself -> rtself

In Class::new closure
itself -> klass

And, name an ignored param to better clarity
_ -> _rtself
