### PR TITLE
Make `Option<VerifiedObject>` a `VerifiedObject`

### DIFF
--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -1397,3 +1397,22 @@ pub trait Object: From<Value> {
         self.value().ty()
     }
 }
+
+impl<Obj: Object> From<Value> for Option<Obj> {
+    fn from(value: Value) -> Option<Obj> {
+        if value.is_nil() {
+            None
+        } else {
+            Some(value.into())
+        }
+    }
+}
+
+impl<Obj: Object> Object for Option<Obj> {
+    fn value(&self) -> Value {
+        match self {
+            Some(val) => val.value(),
+            None => NilClass::new().into(),
+        }
+    }
+}

--- a/src/class/traits/verified_object.rs
+++ b/src/class/traits/verified_object.rs
@@ -1,4 +1,4 @@
-use Object;
+use {NilClass, Object};
 
 /// Interface for safe conversions between types
 ///
@@ -124,4 +124,14 @@ use Object;
 pub trait VerifiedObject: Object {
     fn is_correct_type<T: Object>(object: &T) -> bool;
     fn error_message() -> &'static str;
+}
+
+impl<Obj: VerifiedObject> VerifiedObject for Option<Obj> {
+    fn is_correct_type<T: Object>(object: &T) -> bool {
+        <Obj as VerifiedObject>::is_correct_type(object) ||
+            <NilClass as VerifiedObject>::is_correct_type(object)
+    }
+    fn error_message() -> &'static str {
+        <Obj as VerifiedObject>::error_message()
+    }
 }


### PR DESCRIPTION
This allows people to use `Option<SOME_VERIFIED_OBJECT>` in method signatures
instead of taking AnyObject and converting.