### PR TITLE
Fix build for FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -166,10 +166,10 @@ fn windows_support() {
 #[cfg(not(target_os = "windows"))]
 fn windows_support() {}
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use std::os::unix::fs::symlink;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 fn ruby_lib_link_name() -> String {
     // Rust with linker search paths doesn't seem to use those paths
     // but rather resorts to the systems Ruby.  So we symlink into


### PR DESCRIPTION
Hi folks,

first of all thank you for this very useful library. It makes realizing my current project much easier and more convenient. This PR adds support for FreeBSD as `target_os` is missing. I tested the build for FreeBSD 13.0-CURRENT and 12.1-RELEASE.

Thank you very much!

Best Regards