### PR TITLE
Allowing commas after methods - Issue #120

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -235,6 +235,7 @@ macro_rules! unsafe_methods {
         $(
             fn $method_name: ident
             ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ty $body: block
+            $(,)?
         )*
     ) => {
         $(
@@ -362,6 +363,7 @@ macro_rules! methods {
         $(
             fn $method_name: ident
             ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ident $body: block
+            $(,)?
         )*
     ) => {
         $(


### PR DESCRIPTION
Solve #120.

When multiple methods (functions) are defined inside `methods!` and `unsafe_methods!` macros, commas after the methods is now allowed.
After this change, we can still select the case without commas, as before.

Reference:
* The Rust Reference
* [How to allow optional trailing commas in macros? (Stack Overflow)](https://stackoverflow.com/questions/43143327/how-to-allow-optional-trailing-commas-in-macros)