### PR TITLE
implement VM::call_super -> rb_call_super

### DIFF
--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -25,6 +25,14 @@ pub fn yield_splat(values: Value) -> Value {
     unsafe { vm::rb_yield_splat(values) }
 }
 
+pub fn call_super(arguments: &[Value]) -> Value {
+    let (argc, argv) = util::process_arguments(arguments);
+
+    let result = unsafe { vm::rb_call_super(argc, argv) };
+
+    Value::from(result)
+}
+
 pub fn init() {
     unsafe {
         vm::ruby_init();
@@ -206,6 +214,7 @@ pub fn abort(arguments: &[Value]) {
 }
 
 use util::callback_call::one_parameter as at_exit_callback;
+use rubysys::types::Argc;
 
 pub fn at_exit<F>(func: F)
 where F: FnMut(VmPointer) -> () {

--- a/src/class/module.rs
+++ b/src/class/module.rs
@@ -6,6 +6,7 @@ use typed_data::DataTypeWrapper;
 use types::{Value, ValueType, Callback};
 
 use {AnyObject, Array, Object, Class, VerifiedObject};
+use AnyException;
 
 /// `Module`
 ///

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -774,6 +774,14 @@ impl VM {
     where F: FnMut(VmPointer) -> () {
         vm::at_exit(func)
     }
+
+    pub unsafe fn call_super(arguments: &[AnyObject]) -> AnyObject {
+        let arguments = util::arguments_to_values(arguments);
+
+        let result = vm::call_super(&arguments);
+
+        AnyObject::from(result)
+    }
 }
 
 #[cfg(test)]

--- a/src/rubysys/vm.rs
+++ b/src/rubysys/vm.rs
@@ -69,4 +69,7 @@ extern "C" {
     // VALUE
     // rb_yield(VALUE val)
     pub fn rb_yield(value: Value) -> Value;
+    // VALUE
+    // rb_call_super(int argc, const VALUE *argv)
+    pub fn rb_call_super(argc: Argc, argv: *const Value) -> Value;
 }


### PR DESCRIPTION
This patch adds a way to call super from a method. My use case is ensuring superclass initialize is called from a module that also defines an initialize of it's own (whether or not that's a good idea notwithstanding).

Not sure where to start in writing doc/test for this, open to pointers on next steps before acceptance.