### PR TITLE
Dont require importing the lazy_static macro

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -370,7 +370,7 @@ fn main() {
                     This may mean that your ruby's build config is corrupted. \
                     Possible solution: build a new Ruby with the `--enable-shared` configure opt.";
                     ci_stderr_log!("{}", &msg);
-                    panic!(msg)
+                    panic!("{}", msg)
                 }
             }
         }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -698,7 +698,7 @@ macro_rules! wrappable_struct {
             _marker: ::std::marker::PhantomData<T>,
         }
 
-        lazy_static! {
+        ::lazy_static::lazy_static! {
             pub static ref $static_name: $wrapper<$struct_name> = $wrapper::new();
         }
 


### PR DESCRIPTION
This means that users don't have to add `use lazy_static::lazy_static` or `#[macro_use] extern crate lazy_static` anymore, though they will still have to add the crate as a dependency in their Cargo.toml.