### PR TITLE
feat: Implement `Integer::to_u32` and `Fixnum::to_u32`

### DIFF
--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -105,7 +105,7 @@ impl Fixnum {
     /// # Examples
     ///
     /// ```
-    /// use rutie::{Integer, VM};
+    /// use rutie::{Fixnum, VM};
     /// # VM::init();
     ///
     /// let fixnum = Fixnum::new(1);

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -99,6 +99,28 @@ impl Fixnum {
     pub fn to_i32(&self) -> i32 {
         fixnum::num_to_i32(self.value())
     }
+
+    /// Retrieves a `u32` value from `Fixnum`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Integer, VM};
+    /// # VM::init();
+    ///
+    /// let fixnum = Fixnum::new(1);
+    ///
+    /// assert_eq!(fixnum.to_u32(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_u32(&self) -> u32 {
+        fixnum::num_to_u32(self.value())
+    }
 }
 
 impl From<Value> for Fixnum {

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::fixnum;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, AnyObject};
+use {AnyObject, Object, VerifiedObject};
 
 /// `Fixnum`
 #[derive(Debug)]

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -99,6 +99,28 @@ impl Integer {
     pub fn to_i32(&self) -> i32 {
         fixnum::num_to_i32(self.value())
     }
+
+    /// Retrieves a `u32` value from `Integer`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rutie::{Integer, VM};
+    /// # VM::init();
+    ///
+    /// let integer = Integer::new(1);
+    ///
+    /// assert_eq!(integer.to_u32(), 1);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1 == 1
+    /// ```
+    pub fn to_u32(&self) -> u32 {
+        fixnum::num_to_u32(self.value())
+    }
 }
 
 impl From<Value> for Integer {
@@ -249,6 +271,33 @@ mod tests {
         let num = str_to_num("-1 * 2 ** 31 - 1").unwrap();
         let result = VM::protect(|| { num.to_i32(); nil.into() });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_u32() {
+        let _guard = LOCK_FOR_TEST.write().unwrap();
+        VM::init();
+
+        let nil = NilClass::new();
+
+        let num = str_to_num("1").unwrap();
+        assert_eq!(1, num.to_u32());
+
+        let num = str_to_num("-1").unwrap();
+        assert_eq!(::std::u32::MAX, num.to_u32());
+
+        let num = str_to_num("2 ** 32 - 1").unwrap();
+        assert_eq!(::std::u32::MAX, num.to_u32());
+
+        let num = str_to_num("2 ** 32").unwrap();
+        let result = VM::protect(|| {
+            num.to_u32();
+            nil.into()
+        });
+        assert!(result.is_err());
+
+        let num = str_to_num("0").unwrap();
+        assert_eq!(::std::u32::MIN, num.to_u32());
     }
 
     #[test]

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::fixnum;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, Fixnum, AnyObject};
+use {AnyObject, Fixnum, Object, VerifiedObject};
 
 /// `Integer`
 #[derive(Debug)]
@@ -131,7 +131,9 @@ impl From<Value> for Integer {
 
 impl From<i64> for Integer {
     fn from(num: i64) -> Self {
-        Integer { value: fixnum::i64_to_num(num) }
+        Integer {
+            value: fixnum::i64_to_num(num),
+        }
     }
 }
 
@@ -143,7 +145,9 @@ impl Into<i64> for Integer {
 
 impl From<u64> for Integer {
     fn from(num: u64) -> Self {
-        Integer { value: fixnum::u64_to_num(num) }
+        Integer {
+            value: fixnum::u64_to_num(num),
+        }
     }
 }
 
@@ -155,7 +159,9 @@ impl Into<u64> for Integer {
 
 impl From<i32> for Integer {
     fn from(num: i32) -> Self {
-        Integer { value: fixnum::i32_to_num(num) }
+        Integer {
+            value: fixnum::i32_to_num(num),
+        }
     }
 }
 
@@ -167,7 +173,9 @@ impl Into<i32> for Integer {
 
 impl From<u32> for Integer {
     fn from(num: u32) -> Self {
-        Integer { value: fixnum::u32_to_num(num) }
+        Integer {
+            value: fixnum::u32_to_num(num),
+        }
     }
 }
 
@@ -221,8 +229,8 @@ impl PartialEq for Integer {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::{LOCK_FOR_TEST, AnyException, Object, Integer, VM, NilClass};
     use super::super::super::types::Value;
+    use super::super::super::{AnyException, Integer, NilClass, Object, LOCK_FOR_TEST, VM};
 
     #[test]
     fn test_github_issue_113_darwin_os() {
@@ -262,14 +270,20 @@ mod tests {
         assert_eq!(::std::i32::MAX, num.to_i32());
 
         let num = str_to_num("2 ** 31").unwrap();
-        let result = VM::protect(|| { num.to_i32(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i32();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("-1 * 2 ** 31").unwrap();
         assert_eq!(::std::i32::MIN, num.to_i32());
 
         let num = str_to_num("-1 * 2 ** 31 - 1").unwrap();
-        let result = VM::protect(|| { num.to_i32(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i32();
+            nil.into()
+        });
         assert!(result.is_err());
     }
 
@@ -311,14 +325,20 @@ mod tests {
         assert_eq!(::std::i64::MAX, num.to_i64());
 
         let num = str_to_num("2 ** 63").unwrap();
-        let result = VM::protect(|| { num.to_i64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i64();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("-1 * 2 ** 63").unwrap();
         assert_eq!(::std::i64::MIN, num.to_i64());
 
         let num = str_to_num("-1 * 2 ** 63 - 1").unwrap();
-        let result = VM::protect(|| { num.to_i64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i64();
+            nil.into()
+        });
         assert!(result.is_err());
     }
 
@@ -333,7 +353,10 @@ mod tests {
         assert_eq!(::std::u64::MAX, num.to_u64());
 
         let num = str_to_num("2 ** 64").unwrap();
-        let result = VM::protect(|| { num.to_u64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_u64();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("0").unwrap();


### PR DESCRIPTION
Hello,

This PR adds the `Integer::to_u32` and `Fixnum::to_u32` methods. I'm not sure what to do when we try to convert `-1` (Ruby) to `u32` (Rust). For the moment, it overflows to `std::u32::MAX`. What's the best practise in `rutie`?