### PR TITLE
methods! now uses :ty for return type instead of :ident

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -362,7 +362,7 @@ macro_rules! methods {
         $rtself_name: ident,
         $(
             fn $method_name: ident
-            ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ident $body: block
+            ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ty $body: block
             $(,)?
         )*
     ) => {


### PR DESCRIPTION
The methods! macro uses :ident to match the return type of the functions passed into it. It should use :ty instead.

Here's an example of where the current methods! won't accept a valid return type.

```
methods! {
    Something,
    rtself,
    fn new_tmp() -> ::rutie::AnyObject {
        //          ^^ This is a :ty but not an :ident
        Fixnum::new(123).into()
    }
}
```