### PR TITLE
Fixed not FFI-safe warnings

### DIFF
--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -54,6 +54,7 @@ use std::{
 ///
 /// You can find more examples in `Class`, `Object` and `VerifiedObject` documentation.
 #[derive(Clone, Debug)]
+#[repr(C)]
 pub struct AnyObject {
     value: Value,
 }

--- a/src/class/array.rs
+++ b/src/class/array.rs
@@ -9,6 +9,7 @@ use {AnyObject, Object, RString, VerifiedObject, Enumerator};
 
 /// `Array`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Array {
     value: Value,
 }

--- a/src/class/boolean.rs
+++ b/src/class/boolean.rs
@@ -7,6 +7,7 @@ use {Object, VerifiedObject, AnyObject};
 
 /// `TrueClass` and `FalseClass`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Boolean {
     value: Value,
 }

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -56,6 +56,7 @@ use {AnyObject, Array, Object, Module, VerifiedObject};
 /// end
 /// ```
 #[derive(Debug)]
+#[repr(C)]
 pub struct Class {
     value: Value,
 }

--- a/src/class/encoding.rs
+++ b/src/class/encoding.rs
@@ -4,6 +4,7 @@ use {NilClass, Object, RString, VerifiedObject, Class, AnyException, Exception, 
 use types::{Value, ValueType, EncodingIndex};
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct Encoding {
     value: Value
 }

--- a/src/class/enumerator.rs
+++ b/src/class/enumerator.rs
@@ -14,6 +14,7 @@ use {
 
 /// `Enumerator`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Enumerator {
     value: Value,
 }

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -7,6 +7,7 @@ use {Object, VerifiedObject, AnyObject};
 
 /// `Fixnum`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Fixnum {
     value: Value,
 }

--- a/src/class/float.rs
+++ b/src/class/float.rs
@@ -7,6 +7,7 @@ use {Object, VerifiedObject, AnyObject, AnyException, VM};
 
 /// `Float`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Float {
     value: Value,
 }

--- a/src/class/hash.rs
+++ b/src/class/hash.rs
@@ -8,6 +8,7 @@ use {AnyObject, Object, VerifiedObject};
 
 /// `Hash`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Hash {
     value: Value,
 }

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -7,6 +7,7 @@ use {Object, VerifiedObject, Fixnum, AnyObject};
 
 /// `Integer`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Integer {
     value: Value,
 }

--- a/src/class/module.rs
+++ b/src/class/module.rs
@@ -57,6 +57,7 @@ use {AnyObject, Array, Object, Class, VerifiedObject};
 /// end
 /// ```
 #[derive(Debug)]
+#[repr(C)]
 pub struct Module {
     value: Value,
 }

--- a/src/class/nil_class.rs
+++ b/src/class/nil_class.rs
@@ -8,6 +8,7 @@ use {Object, VerifiedObject, AnyObject};
 
 /// `NilClass`
 #[derive(Debug, Copy, Clone)]
+#[repr(C)]
 pub struct NilClass {
     value: Value,
 }

--- a/src/class/rproc.rs
+++ b/src/class/rproc.rs
@@ -8,6 +8,7 @@ use {AnyObject, Class, Object, VerifiedObject, Boolean};
 
 /// `Proc` (works with `Lambda` as well)
 #[derive(Debug)]
+#[repr(C)]
 pub struct Proc {
     value: Value,
 }

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -23,6 +23,7 @@ use {
 
 /// `String`
 #[derive(Debug)]
+#[repr(C)]
 pub struct RString {
     value: Value,
 }

--- a/src/class/symbol.rs
+++ b/src/class/symbol.rs
@@ -7,6 +7,7 @@ use {Object, VerifiedObject, AnyObject, Proc};
 
 /// `Symbol`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Symbol {
     value: Value,
 }

--- a/src/class/thread.rs
+++ b/src/class/thread.rs
@@ -10,6 +10,7 @@ use {Class, Object, VerifiedObject, AnyObject};
 
 /// `Thread`
 #[derive(Debug)]
+#[repr(C)]
 pub struct Thread {
     value: Value,
 }


### PR DESCRIPTION
Hi, thanks for this project!

This PR fixes `not FFI-safe` warnings when Rutie structs are used as return types.

You can reproduce the warning by building the Ruby example in this repo.

```sh
cd examples/rutie_ruby_example 
cargo build
```

Output

```text
warning: `extern` fn uses type `rutie::RString`, which is not FFI-safe
  --> src/lib.rs:12:39
   |
12 |     fn pub_reverse(input: RString) -> RString {
   |                                       ^^^^^^^ not FFI-safe
   |
   = note: `#[warn(improper_ctypes_definitions)]` on by default
   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
   = note: this struct has unspecified layout

warning: `rutie_ruby_example` (lib) generated 1 warning
```