### PR TITLE
allow(unused_mut) and allow(unused_variables) on methods! rtself arg

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -239,9 +239,10 @@ macro_rules! unsafe_methods {
         )*
     ) => {
         $(
-            #[allow(unused_mut)]
             pub extern fn $method_name(argc: $crate::types::Argc,
                                        argv: *const $crate::AnyObject,
+                                       #[allow(unused_mut)]
+                                       #[allow(unused_variables)]
                                        mut $rtself_name: $rtself_class) -> $return_type {
                 let _arguments = $crate::util::parse_arguments(argc, argv);
                 let mut _i = 0;
@@ -367,9 +368,10 @@ macro_rules! methods {
         )*
     ) => {
         $(
-            #[allow(unused_mut)]
             pub extern fn $method_name(argc: $crate::types::Argc,
                                        argv: *const $crate::AnyObject,
+                                       #[allow(unused_mut)]
+                                       #[allow(unused_variables)]
                                        mut $rtself_name: $rtself_class) -> $return_type {
                 let _arguments = $crate::util::parse_arguments(argc, argv);
                 let mut _i = 0;


### PR DESCRIPTION
This change will stop the warnings generated by `methods!` macroexpansion when `rtself` isn't used in some functions, even though it is in others.

Also it bounds the warning suppression to the `$rtself_name` parameter instead of the entire function body.