### PR TITLE
Mark exception-raising functions as diverging

### DIFF
--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -94,7 +94,7 @@ pub fn eval_string_protect(string: &str) -> Result<Value, c_int> {
     }
 }
 
-pub fn raise(exception: Value, message: &str) {
+pub fn raise(exception: Value, message: &str) -> ! {
     let message = util::str_to_cstring(message);
 
     unsafe {
@@ -102,7 +102,7 @@ pub fn raise(exception: Value, message: &str) {
     }
 }
 
-pub fn raise_ex(exception: Value) {
+pub fn raise_ex(exception: Value) -> ! {
     unsafe { vm::rb_exc_raise(exception); }
 }
 

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -129,7 +129,7 @@ impl VM {
     ///
     /// raise CustomException, 'Something went wrong'
     /// ```
-    pub fn raise(exception: Class, message: &str) {
+    pub fn raise(exception: Class, message: &str) -> ! {
         vm::raise(exception.value(), message);
     }
 
@@ -174,7 +174,7 @@ impl VM {
     ///
     /// raise CustomException, 'Something went wrong'
     /// ```
-    pub fn raise_ex<E>(exception: E) 
+    pub fn raise_ex<E>(exception: E) -> !
     where E: Into<AnyException> {
         vm::raise_ex(exception.into().value());
     }

--- a/src/rubysys/vm.rs
+++ b/src/rubysys/vm.rs
@@ -35,13 +35,13 @@ extern "C" {
     // ///////////////// ///////////////// ///////////////
     // void
     // rb_exc_raise(VALUE mesg)
-    pub fn rb_exc_raise(exception: Value);
+    pub fn rb_exc_raise(exception: Value) -> !;
     // void
     // rb_exit(int status)
     pub fn rb_exit(status: c_int);
     // void
     // rb_raise(VALUE exc, const char *fmt, ...)
-    pub fn rb_raise(exception: Value, message: *const c_char);
+    pub fn rb_raise(exception: Value, message: *const c_char) -> !;
     // VALUE
     // rb_require(const char *fname)
     pub fn rb_require(name: *const c_char) -> Value;


### PR DESCRIPTION
This allows, for example, raising in a match arm without the need to return a dummy value. The following compiles when `VM::raise` diverges:

```rust
fn serialize() -> RString {
    // ...

    match stylesheet.to_css() {
        Ok(output) => RString::new_utf8(&output.code),
        Err(_) => VM::raise(Class::from_existing("StandardError"), "failed to generate CSS")
    }
}
```

Without these changes, the above fails to compile:

    error[E0308]: `match` arms have incompatible types
       --> src/stylesheet.rs:103:23
        |
    101 | /         match stylesheet.to_css() {
    102 | |             Ok(output) => RString::new_utf8(&output.code),
        | |                           ------------------------------- this is found to be of type `rutie::RString`
    103 | |             Err(_) => VM::raise(Class::from_existing("StandardError"), "failed to generate CSS")
        | |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `rutie::RString`, found `()`
    104 | |         }
        | |_________- `match` arms have incompatible types


In general, we no longer need to program as though execution might continue past `VM::raise` when we know it doesn’t.