### PR TITLE
Add support for function parameter trailing commas in 'methods' macro

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -234,7 +234,7 @@ macro_rules! unsafe_methods {
         $rtself_name: ident,
         $(
             fn $method_name: ident
-            ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ty $body: block
+            ($($arg_name: ident: $arg_type: ty),* $(,)?) -> $return_type: ty $body: block
             $(,)?
         )*
     ) => {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -362,7 +362,7 @@ macro_rules! methods {
         $rtself_name: ident,
         $(
             fn $method_name: ident
-            ($($arg_name: ident: $arg_type: ty),*) -> $return_type: ty $body: block
+            ($($arg_name: ident: $arg_type: ty),* $(,)?) -> $return_type: ty $body: block
             $(,)?
         )*
     ) => {


### PR DESCRIPTION
Fixes #164.

I ran the existing tests and everything passed and I reran my example with these changes and it compiled. That said, I have no experience with Rust macros so please let me know if anything needs improvement. I am happy to change or add anything if necessary. :)
