### PR TITLE
Saves the log file of Windows command execution

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,7 +118,7 @@ fn delete<'a>(s: &'a str, from: &'a str) -> String {
 fn purge_refptr_text() {
     let buffer = fs::read_to_string("exports.def")
         .expect("Failed to read 'exports.def'");
-    fs::write("exports.def", delete(&buffer, ".refptr."))
+    fs::write("exports.def", delete( &delete(&buffer, ".refptr."), ".weak."))
         .expect("Failed to write update to 'exports.def'");
 }
 

--- a/build.rs
+++ b/build.rs
@@ -4,14 +4,14 @@ use std::process::Command;
 use std::path::PathBuf;
 use std::env;
 
-#[cfg(target_os = "windows")]
+#[cfg(target_env = "msvc")]
 use {
     std::path::Path,
     std::fs::File,
     std::process::Stdio,
 };
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", all(target_os = "windows", target_env = "gnu"))))]
 use std::fs;
 
 macro_rules! ci_stderr_log {
@@ -41,11 +41,11 @@ fn macos_static_ruby_dep() {
     println!("cargo:rustc-link-lib=framework=Foundation");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(target_env = "msvc"))]
 fn windows_static_ruby_dep() {}
 
 // Windows needs ligmp-10.dll as gmp.lib
-#[cfg(target_os = "windows")]
+#[cfg(target_env = "msvc")]
 fn windows_static_ruby_dep() {
     Command::new("build/windows/vcbuild.cmd")
         .arg("-arch=x64")
@@ -102,7 +102,7 @@ fn use_dylib() {
     ci_stderr_log!("Using dynamic linker flags");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(target_env = "msvc")]
 fn delete<'a>(s: &'a str, from: &'a str) -> String {
     let mut result = String::new();
     let mut last_end = 0;
@@ -114,7 +114,7 @@ fn delete<'a>(s: &'a str, from: &'a str) -> String {
     result
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(target_env = "msvc")]
 fn purge_refptr_text() {
     let buffer = fs::read_to_string("exports.def")
         .expect("Failed to read 'exports.def'");
@@ -122,7 +122,7 @@ fn purge_refptr_text() {
         .expect("Failed to write update to 'exports.def'");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(target_env = "msvc")]
 fn windows_support() {
     println!("cargo:rustc-link-search={}", rbconfig("bindir"));
     let mingw_libs: OsString = env::var_os("MINGW_LIBS").unwrap_or(
@@ -182,7 +182,7 @@ fn windows_support() {
     fs::remove_file("exports.txt").expect("couldn't remove exports.txt");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(target_env = "msvc"))]
 fn windows_support() {}
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]

--- a/build.rs
+++ b/build.rs
@@ -226,7 +226,7 @@ fn ruby_lib_link_name() -> String {
 fn dynamic_linker_args() {
     let mut library = Library::new();
     library.parse_libs_cflags(rbconfig("LIBRUBYARG_SHARED").as_bytes(), false);
-    println!("cargo:rustc-link-lib=dylib={}", ruby_lib_link_name());
+    println!("cargo:rustc-link-lib=dylib=dylib:{}", ruby_lib_link_name());
     library.parse_libs_cflags(rbconfig("LIBS").as_bytes(), false);
 }
 

--- a/src/rubysys/mod.rs
+++ b/src/rubysys/mod.rs
@@ -19,6 +19,7 @@ pub mod vm;
 
 use rubysys::types::Value;
 
+#[link(name="dylib")]
 extern "C" {
     pub static rb_cObject: Value;
 }


### PR DESCRIPTION
I saved each message to a log file when executing commands for Windows.
This makes it possible to identify errors.
Various errors can occur depending on the environment, so I think we should keep a log.

In my environment, the following error occurred when executing lib.exe.

> **********************************************************************
> ** Visual Studio 2019 Developer Command Prompt v16.11.23
> ** Copyright (c) 2021 Microsoft Corporation
> **********************************************************************
> Microsoft (R) Library Manager Version 14.29.30147.0
> Copyright (C) Microsoft Corporation.  All rights reserved.
> 
> exports.def : fatal error LNK1242: '.weak.Init_extra_exts.ruby_push_include' is an invalid export symbol name
> 

Also, in the case of RubyInstaller 3.2.0-1, it had to be "ridk disable".
In the "ridk enable" condition, msys2 GNU toolchain's lib will start.
