### PR TITLE
Running `rustfmt` over Rust code.

### DIFF
--- a/examples/rutie_ruby_example/src/lib.rs
+++ b/examples/rutie_ruby_example/src/lib.rs
@@ -8,19 +8,10 @@ class!(RutieExample);
 methods!(
     RutieExample,
     _rtself,
-
     fn pub_reverse(input: RString) -> RString {
-        let ruby_string = input.
-          map_err(|e| VM::raise_ex(e) ).
-          unwrap();
+        let ruby_string = input.map_err(|e| VM::raise_ex(e)).unwrap();
 
-        RString::new_utf8(
-          &ruby_string.
-          to_string().
-          chars().
-          rev().
-          collect::<String>()
-        )
+        RString::new_utf8(&ruby_string.to_string().chars().rev().collect::<String>())
     }
 );
 

--- a/examples/rutie_ruby_gvl_example/src/lib.rs
+++ b/examples/rutie_ruby_gvl_example/src/lib.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate rutie;
 
-use rutie::{Class, Object, RString, Thread, Fixnum, AnyObject, NilClass};
-use std::sync::mpsc;
+use rutie::{AnyObject, Class, Fixnum, NilClass, Object, RString, Thread};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
+use std::sync::mpsc;
 
 class!(RutieExample);
 
@@ -100,10 +100,22 @@ fn fibonacci(n: u32) -> u32 {
 #[no_mangle]
 pub extern "C" fn Init_rutie_ruby_gvl_example() {
     Class::new("RutieExample", None).define(|klass| {
-        klass.def_self("stack_allocated_returning_input", stack_allocated_returning_input);
-        klass.def_self("stack_allocated_returning_from_closure", stack_allocated_returning_from_closure);
-        klass.def_self("heap_allocated_returning_input", heap_allocated_returning_input);
-        klass.def_self("heap_allocated_returning_from_closure", heap_allocated_returning_from_closure);
+        klass.def_self(
+            "stack_allocated_returning_input",
+            stack_allocated_returning_input,
+        );
+        klass.def_self(
+            "stack_allocated_returning_from_closure",
+            stack_allocated_returning_from_closure,
+        );
+        klass.def_self(
+            "heap_allocated_returning_input",
+            heap_allocated_returning_input,
+        );
+        klass.def_self(
+            "heap_allocated_returning_from_closure",
+            heap_allocated_returning_from_closure,
+        );
         klass.def_self("call_ruby_in_call_with_gvl", call_ruby_in_call_with_gvl);
         klass.def_self("create_thread", create_thread);
     });

--- a/examples/rutie_rust_example/src/main.rs
+++ b/examples/rutie_rust_example/src/main.rs
@@ -18,7 +18,6 @@ fn try_it(s: &str) -> String {
 
 #[test]
 fn it_works() {
-
     // Rust projects must start the Ruby VM
     VM::init();
 

--- a/src/binding/class.rs
+++ b/src/binding/class.rs
@@ -81,7 +81,11 @@ pub fn define_method<I: Object, O: Object>(klass: Value, name: &str, callback: C
     }
 }
 
-pub fn define_private_method<I: Object, O: Object>(klass: Value, name: &str, callback: Callback<I, O>) {
+pub fn define_private_method<I: Object, O: Object>(
+    klass: Value,
+    name: &str,
+    callback: Callback<I, O>,
+) {
     let name = util::str_to_cstring(name);
 
     unsafe {

--- a/src/binding/encoding.rs
+++ b/src/binding/encoding.rs
@@ -1,6 +1,6 @@
 use rubysys::{encoding, string, vm};
-use types::{c_char, size_t, c_int, Value, EncodingIndex, ValueType, EncodingType};
 use std::ffi::CString;
+use types::{c_char, c_int, size_t, EncodingIndex, EncodingType, Value, ValueType};
 use util;
 
 pub fn default_external() -> Value {
@@ -65,13 +65,11 @@ pub fn econv_prepare_opts(opthash: Value, opts: *const Value) -> c_int {
 // end - pointer for the end of the string
 // len_p - a mutable integer pointer for Ruby to give us how much we need to add on to `ptr`
 // enc - the encoding the codepoints will be based on
-pub fn next_codepoint(ptr: *const c_char, end: *const c_char, len_p: *mut c_int, enc: Value) -> usize {
-    unsafe {
-        encoding::rb_enc_codepoint_len(
-            ptr,
-            end,
-            len_p,
-            encoding::rb_to_encoding(enc)
-        )
-    }
+pub fn next_codepoint(
+    ptr: *const c_char,
+    end: *const c_char,
+    len_p: *mut c_int,
+    enc: Value,
+) -> usize {
+    unsafe { encoding::rb_enc_codepoint_len(ptr, end, len_p, encoding::rb_to_encoding(enc)) }
 }

--- a/src/binding/float.rs
+++ b/src/binding/float.rs
@@ -1,6 +1,6 @@
 use rubysys::float;
 use types::Value;
-use ::{Float, AnyException, AnyObject, Object, VM};
+use {AnyException, AnyObject, Float, Object, VM};
 
 pub fn float_to_num(num: f64) -> Value {
     unsafe { float::rb_float_new(num) }
@@ -15,14 +15,12 @@ pub fn implicit_to_f(num: Value) -> Result<Float, AnyException> {
 
     let result = VM::protect(closure);
 
-    result.map(|f| {
-      Float::from(f.value())
-    }).map_err(|_| {
-         let output = VM::error_info().unwrap();
+    result.map(|f| Float::from(f.value())).map_err(|_| {
+        let output = VM::error_info().unwrap();
 
-         // error cleanup
-         VM::clear_error_info();
+        // error cleanup
+        VM::clear_error_info();
 
-         output
-     })
+        output
+    })
 }

--- a/src/binding/gc.rs
+++ b/src/binding/gc.rs
@@ -1,5 +1,5 @@
 use rubysys::gc;
-use types::{ Value, CallbackPtr };
+use types::{CallbackPtr, Value};
 use util;
 
 pub fn adjust_memory_usage(diff: isize) {

--- a/src/binding/hash.rs
+++ b/src/binding/hash.rs
@@ -45,6 +45,10 @@ where
     let closure_ptr = &closure_callback as *const _ as CallbackMutPtr;
 
     unsafe {
-        hash::rb_hash_foreach(hash, each_callback::<F, AnyObject, AnyObject> as CallbackPtr, closure_ptr);
+        hash::rb_hash_foreach(
+            hash,
+            each_callback::<F, AnyObject, AnyObject> as CallbackPtr,
+            closure_ptr,
+        );
     }
 }

--- a/src/binding/module.rs
+++ b/src/binding/module.rs
@@ -1,8 +1,8 @@
 use rubysys::class;
 
-use binding::global::rb_cObject;
 use binding::class as binding_class;
-use types::{Value, Callback, CallbackPtr};
+use binding::global::rb_cObject;
+use types::{Callback, CallbackPtr, Value};
 use util;
 
 use Object;
@@ -19,7 +19,11 @@ pub fn define_nested_module(outer: Value, name: &str) -> Value {
     unsafe { class::rb_define_module_under(outer, name.as_ptr()) }
 }
 
-pub fn define_module_function<I: Object, O: Object>(klass: Value, name: &str, callback: Callback<I, O>) {
+pub fn define_module_function<I: Object, O: Object>(
+    klass: Value,
+    name: &str,
+    callback: Callback<I, O>,
+) {
     let name = util::str_to_cstring(name);
 
     unsafe {

--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -1,4 +1,4 @@
-use rubysys::{string, encoding};
+use rubysys::{encoding, string};
 
 use types::{c_char, c_long, Value};
 use util;

--- a/src/binding/symbol.rs
+++ b/src/binding/symbol.rs
@@ -39,4 +39,3 @@ pub fn internal_id(string: &str) -> Id {
 
     unsafe { symbol::rb_intern2(str, len) }
 }
-

--- a/src/binding/thread.rs
+++ b/src/binding/thread.rs
@@ -2,7 +2,7 @@ use std::ptr;
 
 use rubysys::thread;
 
-use types::{c_void, CallbackPtr, CallbackMutPtr, Value};
+use types::{c_void, CallbackMutPtr, CallbackPtr, Value};
 use util;
 
 #[cfg(unix)]

--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -1,10 +1,10 @@
 use std::ptr;
 
-use ::AnyObject;
 use rubysys::{thread, vm};
+use AnyObject;
 
-use types::{c_int, c_void, CallbackPtr, Value, VmPointer};
 use binding::symbol::internal_id;
+use types::{c_int, c_void, CallbackPtr, Value, VmPointer};
 use util;
 
 pub fn block_proc() -> Value {
@@ -64,29 +64,20 @@ pub fn call_public_method(receiver: Value, method: &str, arguments: &[Value]) ->
 pub fn call_super(arguments: &[Value]) -> Value {
     let (argc, argv) = util::process_arguments(arguments);
 
-    unsafe {
-        vm::rb_call_super(argc, argv)
-    }
+    unsafe { vm::rb_call_super(argc, argv) }
 }
 
 // "evaluation can raise an exception."
 pub fn eval_string(string: &str) -> Value {
     let s = util::str_to_cstring(string);
 
-    unsafe {
-        vm::rb_eval_string(s.as_ptr())
-    }
+    unsafe { vm::rb_eval_string(s.as_ptr()) }
 }
 
 pub fn eval_string_protect(string: &str) -> Result<Value, c_int> {
     let s = util::str_to_cstring(string);
     let mut state = 0;
-    let value = unsafe {
-        vm::rb_eval_string_protect(
-            s.as_ptr(),
-            &mut state as *mut c_int
-        )
-    };
+    let value = unsafe { vm::rb_eval_string_protect(s.as_ptr(), &mut state as *mut c_int) };
     if state == 0 {
         Ok(value)
     } else {
@@ -103,7 +94,9 @@ pub fn raise(exception: Value, message: &str) {
 }
 
 pub fn raise_ex(exception: Value) {
-    unsafe { vm::rb_exc_raise(exception); }
+    unsafe {
+        vm::rb_exc_raise(exception);
+    }
 }
 
 pub fn errinfo() -> Value {
@@ -194,7 +187,11 @@ where
     let mut state = 0;
     let value = unsafe {
         let closure = &func as *const F as *const c_void;
-        vm::rb_protect(callback_protect::<F, AnyObject> as CallbackPtr, closure, &mut state as *mut c_int)
+        vm::rb_protect(
+            callback_protect::<F, AnyObject> as CallbackPtr,
+            closure,
+            &mut state as *mut c_int,
+        )
     };
     if state == 0 {
         Ok(value.into())
@@ -213,14 +210,20 @@ pub fn abort(arguments: &[Value]) {
     unsafe { vm::rb_f_abort(argc, argv) };
 }
 
-use util::callback_call::one_parameter as at_exit_callback;
 use rubysys::types::Argc;
+use util::callback_call::one_parameter as at_exit_callback;
 
 pub fn at_exit<F>(func: F)
-where F: FnMut(VmPointer) -> () {
+where
+    F: FnMut(VmPointer) -> (),
+{
     let mut state = 0;
     unsafe {
         let closure = &func as *const F as *const c_void;
-        vm::rb_protect(at_exit_callback::<F, VmPointer, ()> as CallbackPtr, closure, &mut state as *mut c_int)
+        vm::rb_protect(
+            at_exit_callback::<F, VmPointer, ()> as CallbackPtr,
+            closure,
+            &mut state as *mut c_int,
+        )
     };
 }

--- a/src/class/any_exception.rs
+++ b/src/class/any_exception.rs
@@ -1,14 +1,11 @@
-use ::{Object, VerifiedObject, Exception, NilClass, AnyObject, Class, TryConvert};
-use ::types::{Value, ValueType};
-use std::fmt::{Display, Formatter};
 use std::fmt;
-use std::{
-  ops::Deref,
-  borrow::Borrow,
-};
+use std::fmt::{Display, Formatter};
+use std::{borrow::Borrow, ops::Deref};
+use types::{Value, ValueType};
+use {AnyObject, Class, Exception, NilClass, Object, TryConvert, VerifiedObject};
 
 pub struct AnyException {
-    value: Value
+    value: Value,
 }
 
 impl From<Value> for AnyException {
@@ -69,7 +66,8 @@ impl TryConvert<AnyObject> for AnyException {
     type Nil = NilClass;
 
     fn try_convert(obj: AnyObject) -> Result<Self, NilClass> {
-        obj.try_convert_to::<AnyException>().map_err(|_| NilClass::new() )
+        obj.try_convert_to::<AnyException>()
+            .map_err(|_| NilClass::new())
     }
 }
 

--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -1,11 +1,7 @@
 use types::Value;
 
+use std::{borrow::Borrow, convert::AsRef, ops::Deref};
 use {Object, VerifiedObject};
-use std::{
-  ops::Deref,
-  borrow::Borrow,
-  convert::AsRef,
-};
 
 /// Representation of any Ruby object while its type is unknown
 ///

--- a/src/class/array.rs
+++ b/src/class/array.rs
@@ -5,7 +5,7 @@ use std::iter::{FromIterator, IntoIterator, Iterator};
 use binding::array;
 use types::{Value, ValueType};
 
-use {AnyObject, Object, RString, VerifiedObject, Enumerator};
+use {AnyObject, Enumerator, Object, RString, VerifiedObject};
 
 /// `Array`
 #[derive(Debug)]
@@ -527,8 +527,8 @@ impl Array {
     /// ```
     pub fn to_enum(&self) -> Enumerator {
         unsafe { self.send("to_enum", &[]) }
-                     .try_convert_to::<Enumerator>()
-                     .unwrap()
+            .try_convert_to::<Enumerator>()
+            .unwrap()
     }
 }
 

--- a/src/class/binding.rs
+++ b/src/class/binding.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::rproc;
 use types::{Value, ValueType};
 
-use {Class, Object, VerifiedObject, AnyObject};
+use {AnyObject, Class, Object, VerifiedObject};
 
 /// `Integer`
 #[derive(Debug)]
@@ -29,7 +29,9 @@ impl Binding {
     /// binding
     /// ```
     pub fn new() -> Self {
-        Binding { value: rproc::binding_new() }
+        Binding {
+            value: rproc::binding_new(),
+        }
     }
 }
 

--- a/src/class/boolean.rs
+++ b/src/class/boolean.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use types::Value;
 use util;
 
-use {Object, VerifiedObject, AnyObject};
+use {AnyObject, Object, VerifiedObject};
 
 /// `TrueClass` and `FalseClass`
 #[derive(Debug)]

--- a/src/class/class.rs
+++ b/src/class/class.rs
@@ -1,12 +1,12 @@
 use std::convert::From;
 
-use binding::{class, module};
 use binding::global::rb_cObject;
+use binding::{class, module};
 use typed_data::DataTypeWrapper;
 use types::{Value, ValueType};
 use util;
 
-use {AnyObject, Array, Object, Module, VerifiedObject};
+use {AnyObject, Array, Module, Object, VerifiedObject};
 
 /// `Class`
 ///

--- a/src/class/encoding.rs
+++ b/src/class/encoding.rs
@@ -1,12 +1,12 @@
 use binding::encoding;
 
-use {NilClass, Object, RString, VerifiedObject, Class, AnyException, Exception, AnyObject};
-use types::{Value, ValueType, EncodingIndex};
+use types::{EncodingIndex, Value, ValueType};
+use {AnyException, AnyObject, Class, Exception, NilClass, Object, RString, VerifiedObject};
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct Encoding {
-    value: Value
+    value: Value,
 }
 
 impl Encoding {
@@ -164,7 +164,10 @@ impl Encoding {
         let idx = encoding::find_encoding_index(s);
 
         if idx < 0 {
-            Err(AnyException::new("ArgumentError", Some(&format!("unknown encoding name - {}", s))))
+            Err(AnyException::new(
+                "ArgumentError",
+                Some(&format!("unknown encoding name - {}", s)),
+            ))
         } else {
             Ok(Encoding::from(encoding::from_encoding_index(idx)))
         }
@@ -234,8 +237,8 @@ impl Object for Encoding {
 
 impl VerifiedObject for Encoding {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.value().ty() == ValueType::Class &&
-          Class::from_existing("Encoding").case_equals(object)
+        object.value().ty() == ValueType::Class
+            && Class::from_existing("Encoding").case_equals(object)
     }
 
     fn error_message() -> &'static str {

--- a/src/class/enumerator.rs
+++ b/src/class/enumerator.rs
@@ -2,15 +2,7 @@ use std::convert::From;
 
 use types::{Value, ValueType};
 
-use {
-    AnyObject,
-    AnyException,
-    Array,
-    Class,
-    Fixnum,
-    Object,
-    VerifiedObject,
-};
+use {AnyException, AnyObject, Array, Class, Fixnum, Object, VerifiedObject};
 
 /// `Enumerator`
 #[derive(Debug)]

--- a/src/class/fixnum.rs
+++ b/src/class/fixnum.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::fixnum;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, AnyObject};
+use {AnyObject, Object, VerifiedObject};
 
 /// `Fixnum`
 #[derive(Debug)]

--- a/src/class/float.rs
+++ b/src/class/float.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::float;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, AnyObject, AnyException, VM};
+use {AnyException, AnyObject, Object, VerifiedObject, VM};
 
 /// `Float`
 #[derive(Debug)]

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -1,6 +1,6 @@
 use binding::gc;
 
-use { Object, AnyObject, Symbol };
+use {AnyObject, Object, Symbol};
 
 /// Garbage collection
 pub struct GC;

--- a/src/class/hash.rs
+++ b/src/class/hash.rs
@@ -310,7 +310,7 @@ impl PartialEq for Hash {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::{LOCK_FOR_TEST, Fixnum, Hash, Object, Symbol, VM};
+    use super::super::super::{Fixnum, Hash, Object, Symbol, LOCK_FOR_TEST, VM};
 
     #[test]
     fn test_hash_each() {
@@ -330,8 +330,14 @@ mod tests {
         let mut counter: i64 = 0;
 
         hash.each(|k, v| {
-            assert_eq!(k.try_convert_to::<Symbol>().map(|s| s.to_string()), Ok(format!("key_{}", counter)));
-            assert_eq!(v.try_convert_to::<Fixnum>().map(|f| f.to_i64()), Ok(counter));
+            assert_eq!(
+                k.try_convert_to::<Symbol>().map(|s| s.to_string()),
+                Ok(format!("key_{}", counter))
+            );
+            assert_eq!(
+                v.try_convert_to::<Fixnum>().map(|f| f.to_i64()),
+                Ok(counter)
+            );
 
             counter += 1;
         });

--- a/src/class/integer.rs
+++ b/src/class/integer.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use binding::fixnum;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, Fixnum, AnyObject};
+use {AnyObject, Fixnum, Object, VerifiedObject};
 
 /// `Integer`
 #[derive(Debug)]
@@ -132,7 +132,9 @@ impl From<Value> for Integer {
 
 impl From<i64> for Integer {
     fn from(num: i64) -> Self {
-        Integer { value: fixnum::i64_to_num(num) }
+        Integer {
+            value: fixnum::i64_to_num(num),
+        }
     }
 }
 
@@ -144,7 +146,9 @@ impl Into<i64> for Integer {
 
 impl From<u64> for Integer {
     fn from(num: u64) -> Self {
-        Integer { value: fixnum::u64_to_num(num) }
+        Integer {
+            value: fixnum::u64_to_num(num),
+        }
     }
 }
 
@@ -156,7 +160,9 @@ impl Into<u64> for Integer {
 
 impl From<i32> for Integer {
     fn from(num: i32) -> Self {
-        Integer { value: fixnum::i32_to_num(num) }
+        Integer {
+            value: fixnum::i32_to_num(num),
+        }
     }
 }
 
@@ -168,7 +174,9 @@ impl Into<i32> for Integer {
 
 impl From<u32> for Integer {
     fn from(num: u32) -> Self {
-        Integer { value: fixnum::u32_to_num(num) }
+        Integer {
+            value: fixnum::u32_to_num(num),
+        }
     }
 }
 
@@ -222,8 +230,8 @@ impl PartialEq for Integer {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::{LOCK_FOR_TEST, AnyException, Object, Integer, VM, NilClass};
     use super::super::super::types::Value;
+    use super::super::super::{AnyException, Integer, NilClass, Object, LOCK_FOR_TEST, VM};
 
     #[test]
     fn test_github_issue_113_darwin_os() {
@@ -263,14 +271,20 @@ mod tests {
         assert_eq!(::std::i32::MAX, num.to_i32());
 
         let num = str_to_num("2 ** 31").unwrap();
-        let result = VM::protect(|| { num.to_i32(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i32();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("-1 * 2 ** 31").unwrap();
         assert_eq!(::std::i32::MIN, num.to_i32());
 
         let num = str_to_num("-1 * 2 ** 31 - 1").unwrap();
-        let result = VM::protect(|| { num.to_i32(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i32();
+            nil.into()
+        });
         assert!(result.is_err());
     }
 
@@ -312,14 +326,20 @@ mod tests {
         assert_eq!(::std::i64::MAX, num.to_i64());
 
         let num = str_to_num("2 ** 63").unwrap();
-        let result = VM::protect(|| { num.to_i64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i64();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("-1 * 2 ** 63").unwrap();
         assert_eq!(::std::i64::MIN, num.to_i64());
 
         let num = str_to_num("-1 * 2 ** 63 - 1").unwrap();
-        let result = VM::protect(|| { num.to_i64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_i64();
+            nil.into()
+        });
         assert!(result.is_err());
     }
 
@@ -334,7 +354,10 @@ mod tests {
         assert_eq!(::std::u64::MAX, num.to_u64());
 
         let num = str_to_num("2 ** 64").unwrap();
-        let result = VM::protect(|| { num.to_u64(); nil.into() });
+        let result = VM::protect(|| {
+            num.to_u64();
+            nil.into()
+        });
         assert!(result.is_err());
 
         let num = str_to_num("0").unwrap();

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -1,5 +1,5 @@
-pub mod any_object;
 pub mod any_exception;
+pub mod any_object;
 pub mod array;
 pub mod binding;
 pub mod boolean;
@@ -15,7 +15,7 @@ pub mod module;
 pub mod nil_class;
 pub mod rproc;
 pub mod string;
-pub mod traits;
-pub mod thread;
 pub mod symbol;
+pub mod thread;
+pub mod traits;
 pub mod vm;

--- a/src/class/module.rs
+++ b/src/class/module.rs
@@ -1,11 +1,11 @@
 use std::convert::From;
 
-use binding::{module, class};
 use binding::global::rb_cObject;
+use binding::{class, module};
 use typed_data::DataTypeWrapper;
-use types::{Value, ValueType, Callback};
+use types::{Callback, Value, ValueType};
 
-use {AnyObject, Array, Object, Class, VerifiedObject};
+use {AnyObject, Array, Class, Object, VerifiedObject};
 
 /// `Module`
 ///
@@ -416,7 +416,11 @@ impl Module {
     ///   module_function :pow_with_default_argument
     /// end
     /// ```
-    pub fn define_module_function<I: Object, O: Object>(&mut self, name: &str, callback: Callback<I, O>) {
+    pub fn define_module_function<I: Object, O: Object>(
+        &mut self,
+        name: &str,
+        callback: Callback<I, O>,
+    ) {
         module::define_module_function(self.value(), name, callback);
     }
 

--- a/src/class/nil_class.rs
+++ b/src/class/nil_class.rs
@@ -4,7 +4,7 @@ use std::default::Default;
 use binding::global::RubySpecialConsts;
 use types::{InternalValue, Value, ValueType};
 
-use {Object, VerifiedObject, AnyObject};
+use {AnyObject, Object, VerifiedObject};
 
 /// `NilClass`
 #[derive(Debug, Copy, Clone)]

--- a/src/class/rproc.rs
+++ b/src/class/rproc.rs
@@ -4,7 +4,7 @@ use binding::rproc;
 use types::Value;
 use util;
 
-use {AnyObject, Class, Object, VerifiedObject, Boolean};
+use {AnyObject, Boolean, Class, Object, VerifiedObject};
 
 /// `Proc` (works with `Lambda` as well)
 #[derive(Debug)]

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -1,24 +1,12 @@
 use std::convert::From;
 
-use binding::{encoding, string, vm};
 use binding::class::is_frozen;
+use binding::{encoding, string, vm};
 use types::{Value, ValueType};
 
 use {
-  Object,
-  VerifiedObject,
-  NilClass,
-  AnyObject,
-  EncodingSupport,
-  Encoding,
-  AnyException,
-  Exception,
-  Boolean,
-  TryConvert,
-  Hash,
-  Array,
-  CodepointIterator,
-  Integer,
+    AnyException, AnyObject, Array, Boolean, CodepointIterator, Encoding, EncodingSupport,
+    Exception, Hash, Integer, NilClass, Object, TryConvert, VerifiedObject,
 };
 
 /// `String`
@@ -49,7 +37,10 @@ impl RString {
     ///
     /// str == 'Hello, World!'
     /// ```
-    #[deprecated(since="0.3.2", note="please use `new_usascii_unchecked` or `new_utf8` instead")]
+    #[deprecated(
+        since = "0.3.2",
+        note = "please use `new_usascii_unchecked` or `new_utf8` instead"
+    )]
     pub fn new(string: &str) -> Self {
         Self::new_usascii_unchecked(string)
     }
@@ -309,10 +300,10 @@ impl RString {
     /// str.codepoints == [102, 111, 111, 37727, 97]
     /// ```
     pub fn codepoints(&self) -> Array {
-        CodepointIterator::new(self).
-            into_iter().
-            map(|n| Integer::new(n as i64).to_any_object()).
-            collect()
+        CodepointIterator::new(self)
+            .into_iter()
+            .map(|n| Integer::new(n as i64).to_any_object())
+            .collect()
     }
 
     /// Returns the length of the string in bytes
@@ -418,7 +409,9 @@ impl EncodingSupport for RString {
     /// string.encoding()
     /// ```
     fn encoding(&self) -> Encoding {
-        Encoding::from(encoding::from_encoding_index(encoding::enc_get_index(self.value())))
+        Encoding::from(encoding::from_encoding_index(encoding::enc_get_index(
+            self.value(),
+        )))
     }
 
     /// Changes the encoding to encoding and returns `Result<Self, AnyException>`.
@@ -460,11 +453,17 @@ impl EncodingSupport for RString {
     /// ```
     fn force_encoding(&mut self, enc: Encoding) -> Result<Self, AnyException> {
         if string::is_lockedtmp(self.value()) {
-            return Err(AnyException::new("RuntimeError", Some("can't modify string; temporarily locked")));
+            return Err(AnyException::new(
+                "RuntimeError",
+                Some("can't modify string; temporarily locked"),
+            ));
         }
 
         if self.is_frozen() {
-            return Err(AnyException::new("FrozenError", Some("can't modify frozen String")));
+            return Err(AnyException::new(
+                "FrozenError",
+                Some("can't modify frozen String"),
+            ));
         }
 
         self.value = encoding::force_encoding(self.value(), enc.value());
@@ -498,20 +497,13 @@ impl EncodingSupport for RString {
     fn encode(&self, enc: Encoding, opts: Option<Hash>) -> Self {
         let nil = NilClass::new().value();
 
-         let value = match opts {
+        let value = match opts {
             Some(options) => {
                 let ecflags = encoding::econv_prepare_opts(options.value(), &nil);
 
-                encoding::encode(
-                    self.value(),
-                    enc.value(),
-                    ecflags,
-                    options.value()
-                )
-            },
-            None => {
-                encoding::encode(self.value(), enc.value(), 0, nil)
-            },
+                encoding::encode(self.value(), enc.value(), ecflags, options.value())
+            }
+            None => encoding::encode(self.value(), enc.value(), 0, nil),
         };
 
         Self::from(value)
@@ -687,9 +679,9 @@ impl TryConvert<AnyObject> for RString {
         let result = string::method_to_str(obj.value());
 
         if result.is_nil() {
-            Err( NilClass::from(result) )
+            Err(NilClass::from(result))
         } else {
-            Ok( Self::from(result) )
+            Ok(Self::from(result))
         }
     }
 }

--- a/src/class/symbol.rs
+++ b/src/class/symbol.rs
@@ -3,7 +3,7 @@ use std::{convert::From, hash::Hash, hash::Hasher};
 use binding::symbol;
 use types::{Value, ValueType};
 
-use {Object, VerifiedObject, AnyObject, Proc};
+use {AnyObject, Object, Proc, VerifiedObject};
 
 /// `Symbol`
 #[derive(Debug)]

--- a/src/class/thread.rs
+++ b/src/class/thread.rs
@@ -6,7 +6,7 @@ use types::Value;
 #[cfg(unix)]
 use types::RawFd;
 
-use {Class, Object, VerifiedObject, AnyObject};
+use {AnyObject, Class, Object, VerifiedObject};
 
 /// `Thread`
 #[derive(Debug)]

--- a/src/class/traits/encoding_support.rs
+++ b/src/class/traits/encoding_support.rs
@@ -1,9 +1,13 @@
-use {AnyException, Encoding, Hash, AnyObject, Object};
+use {AnyException, AnyObject, Encoding, Hash, Object};
 
 pub trait EncodingSupport {
-    fn encode(&self, enc: Encoding, opts: Option<Hash>) -> Self where Self: Sized;
+    fn encode(&self, enc: Encoding, opts: Option<Hash>) -> Self
+    where
+        Self: Sized;
     fn encoding(&self) -> Encoding;
-    fn force_encoding(&mut self, enc: Encoding) -> Result<Self, AnyException> where Self: Sized;
+    fn force_encoding(&mut self, enc: Encoding) -> Result<Self, AnyException>
+    where
+        Self: Sized;
     fn is_valid_encoding(&self) -> bool;
     fn compatible_with(&self, other: &impl Object) -> bool;
     fn compatible_encoding(obj1: &impl Object, obj2: &impl Object) -> AnyObject;

--- a/src/class/traits/exception.rs
+++ b/src/class/traits/exception.rs
@@ -1,6 +1,6 @@
-use ::{AnyObject, Object, RString, Array, Class};
 use binding::vm;
 use util;
+use {AnyObject, Array, Class, Object, RString};
 
 /// Descendants of class Exception are used to communicate between Kernel#raise
 /// and rescue statements in `begin ... end` blocks. Exception objects carry
@@ -65,7 +65,11 @@ pub trait Exception: Object {
     fn exception(&self, string: Option<&str>) -> Self {
         let string = string.map(|s| RString::new_utf8(s).value());
 
-        Self::from(vm::call_method(self.value(), "exception", util::option_to_slice(&string)))
+        Self::from(vm::call_method(
+            self.value(),
+            "exception",
+            util::option_to_slice(&string),
+        ))
     }
 
     /// Returns any backtrace associated with the exception. The

--- a/src/class/traits/mod.rs
+++ b/src/class/traits/mod.rs
@@ -1,5 +1,6 @@
-pub mod object;
 pub mod encoding_support;
 pub mod exception;
-pub mod verified_object;
+pub mod object;
 pub mod try_convert;
+pub mod verified_object;
+

--- a/src/class/traits/object.rs
+++ b/src/class/traits/object.rs
@@ -1,13 +1,13 @@
 use std::convert::From;
 
 use binding::class;
-use binding::vm;
 use binding::global::ValueType;
+use binding::vm;
 use typed_data::DataTypeWrapper;
 use types::{Callback, Value};
 use util;
 
-use {AnyObject, AnyException, Exception, Boolean, Class, NilClass, VerifiedObject, VM};
+use {AnyException, AnyObject, Boolean, Class, Exception, NilClass, VerifiedObject, VM};
 
 /// `Object`
 ///
@@ -571,7 +571,11 @@ pub trait Object: From<Value> {
     ///   end
     /// end
     /// ```
-    fn define_private_method<I: Object, O: Object>(&mut self, name: &str, callback: Callback<I, O>) {
+    fn define_private_method<I: Object, O: Object>(
+        &mut self,
+        name: &str,
+        callback: Callback<I, O>,
+    ) {
         class::define_private_method(self.value(), name, callback);
     }
 
@@ -895,8 +899,11 @@ pub trait Object: From<Value> {
     ///     unreachable!()
     /// }
     /// ```
-    fn protect_send(&self, method: &str, arguments: &[AnyObject]) -> Result<AnyObject, AnyException>
-    {
+    fn protect_send(
+        &self,
+        method: &str,
+        arguments: &[AnyObject],
+    ) -> Result<AnyObject, AnyException> {
         let closure = || unsafe { self.send(&method, arguments.as_ref()) };
 
         let result = VM::protect(closure);
@@ -959,7 +966,6 @@ pub trait Object: From<Value> {
         let closure = || vm::call_public_method(v, &method, &arguments).into();
 
         let result = VM::protect(closure);
-
 
         result.map_err(|_| {
             let output = VM::error_info().unwrap();
@@ -1399,7 +1405,8 @@ pub trait Object: From<Value> {
 }
 
 impl<Obj: Object> Object for Option<Obj>
-where Option<Obj>: From<Value>
+where
+    Option<Obj>: From<Value>,
 {
     fn value(&self) -> Value {
         match self {

--- a/src/class/traits/verified_object.rs
+++ b/src/class/traits/verified_object.rs
@@ -1,5 +1,5 @@
-use {NilClass, Object};
 use types::Value;
+use {NilClass, Object};
 
 /// Interface for safe conversions between types
 ///
@@ -128,11 +128,12 @@ pub trait VerifiedObject: Object {
 }
 
 impl<Obj: VerifiedObject> VerifiedObject for Option<Obj>
-where Option<Obj>: From<Value>
+where
+    Option<Obj>: From<Value>,
 {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        <Obj as VerifiedObject>::is_correct_type(object) ||
-            <NilClass as VerifiedObject>::is_correct_type(object)
+        <Obj as VerifiedObject>::is_correct_type(object)
+            || <NilClass as VerifiedObject>::is_correct_type(object)
     }
     fn error_message() -> &'static str {
         <Obj as VerifiedObject>::error_message()

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -1,7 +1,7 @@
 use binding::vm;
 use types::{Argc, Value, VmPointer};
 
-use {AnyObject, AnyException, Class, Object, Proc, NilClass, Array, TryConvert, util};
+use {util, AnyException, AnyObject, Array, Class, NilClass, Object, Proc, TryConvert};
 
 /// Virtual Machine and helpers
 pub struct VM;
@@ -174,8 +174,10 @@ impl VM {
     ///
     /// raise CustomException, 'Something went wrong'
     /// ```
-    pub fn raise_ex<E>(exception: E) 
-    where E: Into<AnyException> {
+    pub fn raise_ex<E>(exception: E)
+    where
+        E: Into<AnyException>,
+    {
         vm::raise_ex(exception.into().value());
     }
 
@@ -234,16 +236,16 @@ impl VM {
     /// with the same content in Ruby, they will evaluate to different values in
     /// C/Rust.
     pub fn eval(string: &str) -> Result<AnyObject, AnyException> {
-        vm::eval_string_protect(string).map(|v|
-            AnyObject::from(v)
-        ).map_err(|_| {
-            let output = AnyException::from(vm::errinfo());
+        vm::eval_string_protect(string)
+            .map(|v| AnyObject::from(v))
+            .map_err(|_| {
+                let output = AnyException::from(vm::errinfo());
 
-            // error cleanup
-            vm::set_errinfo(NilClass::new().value());
+                // error cleanup
+                vm::set_errinfo(NilClass::new().value());
 
-            output
-        })
+                output
+            })
     }
 
     /// Evals string and returns an AnyObject
@@ -271,9 +273,7 @@ impl VM {
     ///
     /// Marked unsafe because "evaluation can raise an exception."
     pub unsafe fn eval_str(string: &str) -> AnyObject {
-        AnyObject::from(
-            vm::eval_string(string)
-        )
+        AnyObject::from(vm::eval_string(string))
     }
 
     /// Converts a block given to current method to a `Proc`
@@ -605,7 +605,6 @@ impl VM {
         vm::set_errinfo(NilClass::new().value());
     }
 
-
     /// Exit with Ruby VM with status code.
     ///
     /// # Examples
@@ -753,8 +752,6 @@ impl VM {
         Class::from_existing("Signal").protect_send("trap", arguments)
     }
 
-
-
     /// `at_exit` is run AFTER the VM is shut down
     ///
     /// # Examples
@@ -771,7 +768,9 @@ impl VM {
     /// VM::at_exit(closure);
     /// ```
     pub fn at_exit<F>(func: F)
-    where F: FnMut(VmPointer) -> () {
+    where
+        F: FnMut(VmPointer) -> (),
+    {
         vm::at_exit(func)
     }
 
@@ -876,7 +875,7 @@ impl VM {
 
 #[cfg(test)]
 mod tests {
-    use ::{LOCK_FOR_TEST, VM};
+    use {LOCK_FOR_TEST, VM};
 
     // cargo test at_exit -- --nocapture
     #[test]

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -79,7 +79,7 @@ macro_rules! class {
                 self.value
             }
         }
-    }
+    };
 }
 
 /// Creates Rust structure for new Ruby module
@@ -163,7 +163,7 @@ macro_rules! module {
                 self.value
             }
         }
-    }
+    };
 }
 
 /// Creates unsafe callbacks for Ruby methods
@@ -768,7 +768,9 @@ macro_rules! wrappable_struct {
 /// ```
 #[macro_export]
 macro_rules! eval {
-    ($string_arg:expr) => {{ $crate::VM::eval($string_arg) }};
+    ($string_arg:expr) => {{
+        $crate::VM::eval($string_arg)
+    }};
     ($string_arg:expr, $binding_arg:expr) => {{
         let eval_str: $crate::AnyObject = $crate::RString::from($string_arg).into();
         let bndng: $crate::AnyObject = $binding_arg.into();

--- a/src/helpers/codepoint_iterator.rs
+++ b/src/helpers/codepoint_iterator.rs
@@ -1,7 +1,7 @@
-use {RString, Object, EncodingSupport};
+use binding::{encoding, string};
+use rubysys::string::{rstring_end, rstring_ptr};
 use types::{c_char, c_int, InternalValue};
-use rubysys::string::{rstring_ptr, rstring_end};
-use binding::{string, encoding};
+use {EncodingSupport, Object, RString};
 
 /// `CodepointIterator`
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused_imports,dead_code)]
+#![allow(unused_imports, dead_code)]
 #[macro_use]
 extern crate lazy_static;
 
@@ -27,8 +27,8 @@ pub use class::float::Float;
 pub use class::gc::GC;
 pub use class::hash::Hash;
 pub use class::integer::Integer;
-pub use class::nil_class::NilClass;
 pub use class::module::Module;
+pub use class::nil_class::NilClass;
 pub use class::rproc::Proc;
 pub use class::string::RString;
 pub use class::symbol::Symbol;
@@ -38,8 +38,8 @@ pub use class::vm::VM;
 pub use class::traits::encoding_support::EncodingSupport;
 pub use class::traits::exception::Exception;
 pub use class::traits::object::Object;
-pub use class::traits::verified_object::VerifiedObject;
 pub use class::traits::try_convert::TryConvert;
+pub use class::traits::verified_object::VerifiedObject;
 
 pub use helpers::codepoint_iterator::CodepointIterator;
 
@@ -53,24 +53,30 @@ lazy_static! {
 #[cfg(test)]
 mod current_ruby {
     use super::*;
-    use std::process::Command;
     use super::{Object, RString, VM};
+    use std::process::Command;
 
     #[test]
     fn is_linked_ruby() {
         let _guard = LOCK_FOR_TEST.write().unwrap();
         VM::init();
-       
+
         let rv = RString::from(VM::eval("RUBY_VERSION").unwrap().value()).to_string();
-        let output = Command::new("ruby").arg("-e").arg("printf RUBY_VERSION").output().unwrap().stdout;
+        let output = Command::new("ruby")
+            .arg("-e")
+            .arg("printf RUBY_VERSION")
+            .output()
+            .unwrap()
+            .stdout;
         let crv = String::from_utf8_lossy(&output);
-       
-        assert_eq!(rv, crv,
-                   "\nCurrent console Ruby is version {} but the \
+
+        assert_eq!(
+            rv, crv,
+            "\nCurrent console Ruby is version {} but the \
                    linked Ruby is version {} \
                    Please run `cargo clean` first to remove previously used symbolic link in \
-                   the dependency directory.", crv, rv
+                   the dependency directory.",
+            crv, rv
         );
     }
-   
 }

--- a/src/rubysys/class.rs
+++ b/src/rubysys/class.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{Argc, c_char, c_int, CallbackPtr, Id, Value};
+use rubysys::types::{c_char, c_int, Argc, CallbackPtr, Id, Value};
 
 extern "C" {
     // VALUE
@@ -30,19 +30,31 @@ extern "C" {
     pub fn rb_define_module(name: *const c_char) -> Value;
     // void
     // rb_define_module_function(VALUE module, const char *name, VALUE (*func)(ANYARGS), int argc)
-    pub fn rb_define_module_function(klass: Value, name: *const c_char, callback: CallbackPtr, argc: Argc);
+    pub fn rb_define_module_function(
+        klass: Value,
+        name: *const c_char,
+        callback: CallbackPtr,
+        argc: Argc,
+    );
     // VALUE
     // rb_define_module_under(VALUE outer, const char *name)
     pub fn rb_define_module_under(outer: Value, name: *const c_char) -> Value;
     // void
     // rb_define_private_method(VALUE klass, const char *name, VALUE (*func)(ANYARGS), int argc)
-    pub fn rb_define_private_method(klass: Value, name: *const c_char, callback: CallbackPtr, argc: Argc);
+    pub fn rb_define_private_method(
+        klass: Value,
+        name: *const c_char,
+        callback: CallbackPtr,
+        argc: Argc,
+    );
     // void
     // rb_define_singleton_method(VALUE obj, const char *name, VALUE (*func)(ANYARGS), int argc)
-    pub fn rb_define_singleton_method(klass: Value,
-                                      name: *const c_char,
-                                      callback: CallbackPtr,
-                                      argc: Argc);
+    pub fn rb_define_singleton_method(
+        klass: Value,
+        name: *const c_char,
+        callback: CallbackPtr,
+        argc: Argc,
+    );
     // VALUE
     // rb_eql(VALUE obj1, VALUE obj2)
     pub fn rb_eql(obj1: Value, obj2: Value) -> Value;

--- a/src/rubysys/constant.rs
+++ b/src/rubysys/constant.rs
@@ -1,40 +1,39 @@
 use rubysys::value::ValueType;
 
-pub const FL_WB_PROTECTED: isize  = 1<<5;
-pub const FL_PROMOTED0   : isize  = 1<<5;
-pub const FL_PROMOTED1   : isize  = 1<<6;
-pub const FL_PROMOTED    : isize  = FL_PROMOTED0|FL_PROMOTED1;
-pub const FL_FINALIZE    : isize  = 1<<7;
-pub const FL_TAINT       : isize  = 1<<8;
-pub const FL_UNTRUSTED   : isize  = FL_TAINT;
-pub const FL_EXIVAR      : isize  = 1<<10;
-pub const FL_FREEZE      : isize  = 1<<11;
+pub const FL_WB_PROTECTED: isize = 1 << 5;
+pub const FL_PROMOTED0: isize = 1 << 5;
+pub const FL_PROMOTED1: isize = 1 << 6;
+pub const FL_PROMOTED: isize = FL_PROMOTED0 | FL_PROMOTED1;
+pub const FL_FINALIZE: isize = 1 << 7;
+pub const FL_TAINT: isize = 1 << 8;
+pub const FL_UNTRUSTED: isize = FL_TAINT;
+pub const FL_EXIVAR: isize = 1 << 10;
+pub const FL_FREEZE: isize = 1 << 11;
 
-pub const FL_USHIFT      : isize = 12;
+pub const FL_USHIFT: isize = 12;
 
-pub const FL_USER_0      : isize = 1 << (FL_USHIFT + 0);
-pub const FL_USER_1      : isize = 1 << (FL_USHIFT + 1);
-pub const FL_USER_2      : isize = 1 << (FL_USHIFT + 2);
-pub const FL_USER_3      : isize = 1 << (FL_USHIFT + 3);
-pub const FL_USER_4      : isize = 1 << (FL_USHIFT + 4);
-pub const FL_USER_5      : isize = 1 << (FL_USHIFT + 5);
-pub const FL_USER_6      : isize = 1 << (FL_USHIFT + 6);
-pub const FL_USER_7      : isize = 1 << (FL_USHIFT + 7);
-pub const FL_USER_8      : isize = 1 << (FL_USHIFT + 8);
-pub const FL_USER_9      : isize = 1 << (FL_USHIFT + 9);
-pub const FL_USER_10     : isize = 1 << (FL_USHIFT + 10);
-pub const FL_USER_11     : isize = 1 << (FL_USHIFT + 11);
-pub const FL_USER_12     : isize = 1 << (FL_USHIFT + 12);
-pub const FL_USER_13     : isize = 1 << (FL_USHIFT + 13);
-pub const FL_USER_14     : isize = 1 << (FL_USHIFT + 14);
-pub const FL_USER_15     : isize = 1 << (FL_USHIFT + 15);
-pub const FL_USER_16     : isize = 1 << (FL_USHIFT + 16);
-pub const FL_USER_17     : isize = 1 << (FL_USHIFT + 17);
-pub const FL_USER_18     : isize = 1 << (FL_USHIFT + 18);
+pub const FL_USER_0: isize = 1 << (FL_USHIFT + 0);
+pub const FL_USER_1: isize = 1 << (FL_USHIFT + 1);
+pub const FL_USER_2: isize = 1 << (FL_USHIFT + 2);
+pub const FL_USER_3: isize = 1 << (FL_USHIFT + 3);
+pub const FL_USER_4: isize = 1 << (FL_USHIFT + 4);
+pub const FL_USER_5: isize = 1 << (FL_USHIFT + 5);
+pub const FL_USER_6: isize = 1 << (FL_USHIFT + 6);
+pub const FL_USER_7: isize = 1 << (FL_USHIFT + 7);
+pub const FL_USER_8: isize = 1 << (FL_USHIFT + 8);
+pub const FL_USER_9: isize = 1 << (FL_USHIFT + 9);
+pub const FL_USER_10: isize = 1 << (FL_USHIFT + 10);
+pub const FL_USER_11: isize = 1 << (FL_USHIFT + 11);
+pub const FL_USER_12: isize = 1 << (FL_USHIFT + 12);
+pub const FL_USER_13: isize = 1 << (FL_USHIFT + 13);
+pub const FL_USER_14: isize = 1 << (FL_USHIFT + 14);
+pub const FL_USER_15: isize = 1 << (FL_USHIFT + 15);
+pub const FL_USER_16: isize = 1 << (FL_USHIFT + 16);
+pub const FL_USER_17: isize = 1 << (FL_USHIFT + 17);
+pub const FL_USER_18: isize = 1 << (FL_USHIFT + 18);
 
-
-pub const ELTS_SHARED : isize = FL_USER_2;
-pub const FL_DUPPED   : isize = ValueType::Mask as isize|FL_EXIVAR|FL_TAINT;
+pub const ELTS_SHARED: isize = FL_USER_2;
+pub const FL_DUPPED: isize = ValueType::Mask as isize | FL_EXIVAR | FL_TAINT;
 pub const FL_SINGLETON: isize = FL_USER_0;
 
 pub const UNLIMITED_ARGUMENTS: isize = -1;

--- a/src/rubysys/encoding.rs
+++ b/src/rubysys/encoding.rs
@@ -1,24 +1,17 @@
-use rubysys::types::{
-  size_t,
-  c_int,
-  c_char,
-  Value,
-  CallbackPtr,
-  RBasic,
-  InternalValue,
-  EncodingIndex,
-  EncodingType
-};
 use rubysys::constant::{FL_USER_8, FL_USER_9};
+use rubysys::types::{
+    c_char, c_int, size_t, CallbackPtr, EncodingIndex, EncodingType, InternalValue, RBasic, Value,
+};
 use std::mem;
 
-pub const ENC_DUMMY_FLAG: isize        = 1<<24;
-pub const ENC_INDEX_MASK: isize        = !(!0<<24);
+pub const ENC_DUMMY_FLAG: isize = 1 << 24;
+pub const ENC_INDEX_MASK: isize = !(!0 << 24);
 pub const ENC_CODERANGE_UNKNOWN: isize = 0;
-pub const ENC_CODERANGE_7BIT: isize    = FL_USER_8;
-pub const ENC_CODERANGE_VALID: isize   = FL_USER_9;
-pub const ENC_CODERANGE_BROKEN: isize  = FL_USER_8 | FL_USER_9;
-pub const ENC_CODERANGE_MASK: isize    = ENC_CODERANGE_7BIT | ENC_CODERANGE_VALID | ENC_CODERANGE_BROKEN;
+pub const ENC_CODERANGE_7BIT: isize = FL_USER_8;
+pub const ENC_CODERANGE_VALID: isize = FL_USER_9;
+pub const ENC_CODERANGE_BROKEN: isize = FL_USER_8 | FL_USER_9;
+pub const ENC_CODERANGE_MASK: isize =
+    ENC_CODERANGE_7BIT | ENC_CODERANGE_VALID | ENC_CODERANGE_BROKEN;
 
 extern "C" {
     // VALUE
@@ -95,7 +88,12 @@ extern "C" {
     pub fn rb_econv_prepare_opts(opthash: Value, opts: *const Value) -> c_int;
     // unsigned int
     // rb_enc_codepoint_len(const char *p, const char *e, int *len_p, rb_encoding *enc)
-    pub fn rb_enc_codepoint_len(ptr: *const c_char, end: *const c_char, len_p: *mut c_int, enc: EncodingType) -> size_t;
+    pub fn rb_enc_codepoint_len(
+        ptr: *const c_char,
+        end: *const c_char,
+        len_p: *mut c_int,
+        enc: EncodingType,
+    ) -> size_t;
 }
 
 pub unsafe fn coderange_set(obj: Value, code_range: InternalValue) {

--- a/src/rubysys/gc.rs
+++ b/src/rubysys/gc.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{c_int, size_t, ssize_t, Value, CallbackPtr};
+use rubysys::types::{c_int, size_t, ssize_t, CallbackPtr, Value};
 
 extern "C" {
     // void

--- a/src/rubysys/hash.rs
+++ b/src/rubysys/hash.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{CallbackPtr, CallbackMutPtr, Value};
+use rubysys::types::{CallbackMutPtr, CallbackPtr, Value};
 
 extern "C" {
     // VALUE

--- a/src/rubysys/mod.rs
+++ b/src/rubysys/mod.rs
@@ -1,12 +1,12 @@
 extern crate libc;
 
 pub mod array;
-pub mod constant;
 pub mod class;
+pub mod constant;
 pub mod encoding;
 pub mod fixnum;
-pub mod gc;
 pub mod float;
+pub mod gc;
 pub mod hash;
 pub mod rproc;
 pub mod string;

--- a/src/rubysys/rproc.rs
+++ b/src/rubysys/rproc.rs
@@ -1,15 +1,16 @@
-use rubysys::types::{Argc, Value, c_int};
 use rubysys::constant::UNLIMITED_ARGUMENTS;
+use rubysys::types::{c_int, Argc, Value};
 use {AnyException, Exception};
 
 extern "C" {
     // VALUE
     // rb_proc_call_with_block(VALUE self, int argc, const VALUE *argv, VALUE passed_procval)
-    pub fn rb_proc_call_with_block(rproc: Value,
-                                   argc: Argc,
-                                   argv: *const Value,
-                                   pass_procval: Value)
-                                   -> Value;
+    pub fn rb_proc_call_with_block(
+        rproc: Value,
+        argc: Argc,
+        argv: *const Value,
+        pass_procval: Value,
+    ) -> Value;
     // VALUE
     // rb_binding_new(void)
     pub fn rb_binding_new() -> Value;
@@ -20,11 +21,20 @@ extern "C" {
 pub fn check_arity(argc: c_int, min: c_int, max: c_int) -> Result<c_int, AnyException> {
     if argc < min || (max != UNLIMITED_ARGUMENTS as c_int && argc > max) {
         let err_mess = if min == max {
-            format!("wrong number of arguments (given {}, expected {})", argc, min)
+            format!(
+                "wrong number of arguments (given {}, expected {})",
+                argc, min
+            )
         } else if max == UNLIMITED_ARGUMENTS as c_int {
-            format!("wrong number of arguments (given {}, expected {}+)", argc, min)
+            format!(
+                "wrong number of arguments (given {}, expected {}+)",
+                argc, min
+            )
         } else {
-            format!("wrong number of arguments (given {}, expected {}..{})", argc, min, max)
+            format!(
+                "wrong number of arguments (given {}, expected {}..{})",
+                argc, min, max
+            )
         };
 
         return Err(AnyException::new("ArgumentError", Some(&err_mess)));

--- a/src/rubysys/string.rs
+++ b/src/rubysys/string.rs
@@ -2,9 +2,10 @@ use rubysys::libc::size_t;
 use std::mem;
 
 use rubysys::constant::{
-    FL_USHIFT, FL_USER_1, FL_USER_2, FL_USER_3, FL_USER_4, FL_USER_5, FL_USER_6, FL_USER_7, FL_USER_17
+    FL_USER_1, FL_USER_17, FL_USER_2, FL_USER_3, FL_USER_4, FL_USER_5, FL_USER_6, FL_USER_7,
+    FL_USHIFT,
 };
-use rubysys::types::{c_char, c_long, InternalValue, RBasic, Value, CallbackPtr, EncodingType};
+use rubysys::types::{c_char, c_long, CallbackPtr, EncodingType, InternalValue, RBasic, Value};
 
 pub const STR_TMPLOCK: isize = FL_USER_7;
 
@@ -78,7 +79,7 @@ enum RStringEmbed {
     NoEmbed = FL_USER_1,
     LenMask = FL_USER_2 | FL_USER_3 | FL_USER_4 | FL_USER_5 | FL_USER_6,
     LenShift = FL_USHIFT + 2,
-    LenMax = (mem::size_of::<Value>() as isize * 3)/mem::size_of::<c_char>() as isize - 1,
+    LenMax = (mem::size_of::<Value>() as isize * 3) / mem::size_of::<c_char>() as isize - 1,
     Fstr = FL_USER_17,
 }
 
@@ -124,8 +125,8 @@ unsafe fn embed_check(flags: InternalValue) -> bool {
 pub unsafe fn rstring_embed_len(value: Value) -> c_long {
     let (_rstring, flags) = rstring_and_flags(value);
 
-    ((flags as i64 >> RStringEmbed::LenShift as i64) &
-      (RStringEmbed::LenMask as i64 >> RStringEmbed::LenShift as i64)) as c_long
+    ((flags as i64 >> RStringEmbed::LenShift as i64)
+        & (RStringEmbed::LenMask as i64 >> RStringEmbed::LenShift as i64)) as c_long
 }
 
 pub unsafe fn rstring_len(value: Value) -> c_long {
@@ -152,9 +153,17 @@ pub unsafe fn rstring_end(value: Value) -> *const c_char {
     let (rstring, flags) = rstring_and_flags(value);
 
     if embed_check(flags) {
-        (*rstring).as_.ary.as_ptr().add(rstring_embed_len(value) as usize)
+        (*rstring)
+            .as_
+            .ary
+            .as_ptr()
+            .add(rstring_embed_len(value) as usize)
     } else {
-        (*rstring).as_.heap.ptr.add((*rstring).as_.heap.len as usize)
+        (*rstring)
+            .as_
+            .heap
+            .ptr
+            .add((*rstring).as_.heap.len as usize)
     }
 }
 

--- a/src/rubysys/thread.rs
+++ b/src/rubysys/thread.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{CallbackPtr, c_void, Value, c_int};
+use rubysys::types::{c_int, c_void, CallbackPtr, Value};
 
 #[cfg(unix)]
 use rubysys::types::RawFd;
@@ -91,20 +91,22 @@ extern "C" {
     // void *
     // rb_thread_call_without_gvl(void *(*func)(void *data), void *data1,
     //                            rb_unblock_function_t *ubf, void *data2)
-    pub fn rb_thread_call_without_gvl(func: CallbackPtr,
-                                      args: *const c_void,
-                                      unblock_func: CallbackPtr,
-                                      unblock_args: *const c_void)
-                                      -> *mut c_void;
+    pub fn rb_thread_call_without_gvl(
+        func: CallbackPtr,
+        args: *const c_void,
+        unblock_func: CallbackPtr,
+        unblock_args: *const c_void,
+    ) -> *mut c_void;
 
     // void *
     // rb_thread_call_without_gvl2(void *(*func)(void *), void *data1,
     //                             rb_unblock_function_t *ubf, void *data2)
-    pub fn rb_thread_call_without_gvl2(func: CallbackPtr,
-                                       args: *const c_void,
-                                       unblock_func: CallbackPtr,
-                                       unblock_args: *const c_void)
-                                       -> *mut c_void;
+    pub fn rb_thread_call_without_gvl2(
+        func: CallbackPtr,
+        args: *const c_void,
+        unblock_func: CallbackPtr,
+        unblock_args: *const c_void,
+    ) -> *mut c_void;
 
     // rb_thread_call_with_gvl - re-enter the Ruby world after GVL release.
     //
@@ -139,9 +141,10 @@ extern "C" {
 
     // VALUE
     // rb_thread_create(VALUE (*fn)(ANYARGS), void *arg)
-    pub fn rb_thread_create(function: extern "C" fn(*mut c_void) -> Value,
-                            data: *mut c_void)
-                            -> Value;
+    pub fn rb_thread_create(
+        function: extern "C" fn(*mut c_void) -> Value,
+        data: *mut c_void,
+    ) -> Value;
 
     // void
     // rb_thread_wait_fd(int fd)

--- a/src/rubysys/types.rs
+++ b/src/rubysys/types.rs
@@ -20,7 +20,7 @@ pub type VmPointer = CallbackPtr;
 pub type Argc = c_int;
 pub type CallbackPtr = *const c_void;
 pub type CallbackMutPtr = *mut c_void;
-pub type BlockCallFunction = extern fn(
+pub type BlockCallFunction = extern "C" fn(
     yielded_arg: Value,
     callback_arg: Value,
     argc: c_int,

--- a/src/rubysys/value.rs
+++ b/src/rubysys/value.rs
@@ -1,6 +1,6 @@
-use std::mem;
-use std::convert::From;
 use rubysys::constant;
+use std::convert::From;
+use std::mem;
 
 use rubysys::types::{InternalValue, RBasic};
 
@@ -113,8 +113,8 @@ impl Value {
     }
 
     pub fn is_flonum(&self) -> bool {
-        (self.value & (RubySpecialFlags::FlonumMask as InternalValue)) ==
-        (RubySpecialFlags::FlonumFlag as InternalValue)
+        (self.value & (RubySpecialFlags::FlonumMask as InternalValue))
+            == (RubySpecialFlags::FlonumFlag as InternalValue)
     }
 
     pub fn is_frozen(&self) -> bool {
@@ -183,6 +183,8 @@ impl Value {
 
 impl From<InternalValue> for Value {
     fn from(internal_value: InternalValue) -> Self {
-        Value { value: internal_value }
+        Value {
+            value: internal_value,
+        }
     }
 }

--- a/src/rubysys/vm.rs
+++ b/src/rubysys/vm.rs
@@ -1,4 +1,4 @@
-use rubysys::types::{CallbackPtr, c_char, c_int, c_void, Value, Id, Argc, VmPointer};
+use rubysys::types::{c_char, c_int, c_void, Argc, CallbackPtr, Id, Value, VmPointer};
 
 extern "C" {
     // void
@@ -56,13 +56,19 @@ extern "C" {
     pub fn rb_funcallv(receiver: Value, method: Id, argc: Argc, argv: *const Value) -> Value;
     // VALUE
     // rb_funcallv_public(VALUE recv, ID mid, int argc, const VALUE *argv)
-    pub fn rb_funcallv_public(receiver: Value, method: Id, argc: Argc, argv: *const Value) -> Value;
+    pub fn rb_funcallv_public(receiver: Value, method: Id, argc: Argc, argv: *const Value)
+        -> Value;
     // VALUE
     // rb_block_call(VALUE obj, ID mid, int argc, const VALUE * argv,
     //               VALUE (*bl_proc) (ANYARGS), VALUE data2)
-    pub fn rb_block_call(obj: Value, method_id: Id, argc: Argc, argv: *const Value,
-                         block: extern fn(Value, Value, Argc, *const Value) -> Value,
-                         outer_scope: Value) -> Value;
+    pub fn rb_block_call(
+        obj: Value,
+        method_id: Id,
+        argc: Argc,
+        argv: *const Value,
+        block: extern "C" fn(Value, Value, Argc, *const Value) -> Value,
+        outer_scope: Value,
+    ) -> Value;
     // VALUE
     // rb_yield_splat(VALUE values)
     pub fn rb_yield_splat(values: Value) -> Value;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,10 @@
 use AnyObject;
 
-pub use rubysys::types::{c_char, c_int, c_long, c_void, size_t, st_retval, Argc, CallbackMutPtr, CallbackPtr,
-                         EncodingIndex, EncodingType, Id, InternalValue, RbDataType as DataType,
-                         RbDataTypeFunction as DataTypeFunction, SignedValue, Value, ValueType, VmPointer};
+pub use rubysys::types::{
+    c_char, c_int, c_long, c_void, size_t, st_retval, Argc, CallbackMutPtr, CallbackPtr,
+    EncodingIndex, EncodingType, Id, InternalValue, RbDataType as DataType,
+    RbDataTypeFunction as DataTypeFunction, SignedValue, Value, ValueType, VmPointer,
+};
 
 #[cfg(unix)]
 pub use rubysys::types::RawFd;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,16 +2,13 @@ use std::ffi::{CStr, CString};
 use std::ptr;
 use std::slice;
 
-use binding::global::{RubySpecialConsts, rb_cObject};
 use binding::class::const_get;
+use binding::global::{rb_cObject, RubySpecialConsts};
 use binding::vm;
 use types::{c_char, c_int, c_void, Argc, InternalValue, Value};
 
-use {AnyObject, Object, Boolean};
-use crate::rubysys::rproc::{
-    rb_obj_is_proc,
-    rb_obj_is_method,
-};
+use crate::rubysys::rproc::{rb_obj_is_method, rb_obj_is_proc};
+use {AnyObject, Boolean, Object};
 
 pub unsafe fn cstr_to_string(str: *const c_char) -> String {
     CStr::from_ptr(str).to_string_lossy().into_owned()
@@ -124,7 +121,7 @@ pub fn inmost_rb_object(klass: &str) -> Value {
 }
 
 pub mod callback_call {
-    use ::types::{c_void, CallbackMutPtr, st_retval};
+    use types::{c_void, st_retval, CallbackMutPtr};
 
     pub fn no_parameters<F: FnMut() -> R, R>(ptr: CallbackMutPtr) -> R {
         let f = ptr as *mut F;
@@ -136,9 +133,15 @@ pub mod callback_call {
         unsafe { (*f)(a) }
     }
 
-    pub fn hash_foreach_callback<F: FnMut(A, B), A, B>(a: A, b: B, ptr: CallbackMutPtr) -> st_retval {
+    pub fn hash_foreach_callback<F: FnMut(A, B), A, B>(
+        a: A,
+        b: B,
+        ptr: CallbackMutPtr,
+    ) -> st_retval {
         let f = ptr as *mut F;
-        unsafe { (*f)(a, b); }
+        unsafe {
+            (*f)(a, b);
+        }
         st_retval::Continue
     }
 }


### PR DESCRIPTION
While trying to work in the `rb-sys` migration I noticed that `rustfmt` via `rust-analyzer` and (Neovim `rust-tools`) was formatting stuff.

Since I don't have any custom config for rustfmt I suspect this is probably gonna happen to any contributor adding lots of noise to PRs.

No functional changes intended.

Changes `rustfmt` has doneas far as I can see are:

- Sorting of imports alphabetically.
- Split single line method definition arguments into multiple lines.
- Leading spaces removal.
- Some multi-line calls were folded into single-line.