### PR TITLE
Use native Ruby function for getting a string's length

### DIFF
--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -62,7 +62,7 @@ pub fn value_to_str<'a>(value: Value) -> &'a str {
 pub fn value_to_bytes_unchecked<'a>(value: Value) -> &'a [u8] {
     unsafe {
         let str = string::rb_string_value_ptr(&value) as *const u8;
-        let len = string::rstring_len(value) as usize;
+        let len = string::rb_str_strlen(value) as usize;
 
         ::std::slice::from_raw_parts(str, len)
     }


### PR DESCRIPTION
Without this change, Ruby 3.2 was failing to correctly provide me with strings, because the length was always set to zero.

I'm not sure exactly what the change in 3.2 that triggered the problem, but given that rutie's `rstring_len` appears to be an implementation of a function in CRuby that's named `rbimpl_` (which is a namespace meaning "no compatibility should be expected", I don't think this is Ruby's fault.