### PR TITLE
Removed GC::force_recycle on 3.4

### DIFF
--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -78,6 +78,7 @@ impl GC {
     ///
     /// GC::force_recycle(obj);
     /// ```
+    #[cfg(not(ruby_gt_3_3))]
     pub fn force_recycle(object: impl Object) {
         gc::force_recycle(object.value())
     }


### PR DESCRIPTION
Hello,

At first, thank you for creating and maintaining this library. I experienced fun with Ruby and Rust programming and maintain a gem created using Rutie.

This pull request make it ignore `GC::force_recycle`, which was removed since Ruby 3.4 (see [Feature #18290 on Ruby issue tracker](https://bugs.ruby-lang.org/issues/18290)), and fixes #175.

Thank you.